### PR TITLE
Added REST input parser respod success in JSON

### DIFF
--- a/notification/.gitignore
+++ b/notification/.gitignore
@@ -226,3 +226,69 @@ buildNumber.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/

--- a/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/NotificationPlugin.kt
+++ b/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/NotificationPlugin.kt
@@ -62,7 +62,7 @@ internal class NotificationPlugin : ActionPlugin, Plugin() {
       indexNameExpressionResolver: IndexNameExpressionResolver,
       nodesInCluster: Supplier<DiscoveryNodes>
     ): List<RestHandler> {
-        log.debug("getRestHandlers called")
+        log.debug("$PLUGIN_NAME:getRestHandlers")
         return listOf(
           SendRestHandler()
         )
@@ -81,18 +81,18 @@ internal class NotificationPlugin : ActionPlugin, Plugin() {
       indexNameExpressionResolver: IndexNameExpressionResolver,
       repositoriesServiceSupplier: Supplier<RepositoriesService>
     ): Collection<Any> {
-        log.debug("createComponents called")
+        log.debug("$PLUGIN_NAME:createComponents")
         this.clusterService = clusterService
         return listOf()
     }
 
     override fun getSettings(): List<Setting<*>> {
-        log.debug("getSettings called")
+        log.debug("$PLUGIN_NAME:getSettings")
         return listOf()
     }
 
     override fun getActions(): List<ActionPlugin.ActionHandler<out ActionRequest, out ActionResponse>> {
-        log.debug("getActions called")
+        log.debug("$PLUGIN_NAME:getActions")
         return listOf()
     }
 }

--- a/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/core/NotificationMessage.kt
+++ b/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/core/NotificationMessage.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.notification.core
+
+class NotificationMessage(
+  val refTag: String,
+  val title: String,
+  val recipients: List<String>,
+  val textDescription: String?,
+  val htmlDescription: String?,
+  val binaryData: String?,
+  val textData: String?
+)

--- a/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/core/RestRequestParser.kt
+++ b/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/core/RestRequestParser.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.notification.core
+
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
+import org.elasticsearch.rest.RestRequest
+
+object RestRequestParser {
+    private val log = LogManager.getLogger(javaClass)
+
+    fun parse(request: RestRequest): NotificationMessage {
+        var type: String? = null
+        var message: NotificationMessage? = null
+        val contentParser = request.contentOrSourceParamParser()
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, contentParser.nextToken(), contentParser::getTokenLocation)
+        while (contentParser.nextToken() != XContentParser.Token.END_OBJECT) {
+            val fieldName = contentParser.currentName()
+            contentParser.nextToken()
+            when (fieldName) {
+                "type" -> type = contentParser.text()
+                "params" -> { message = parseNotificationMessage(contentParser) }
+                else -> {
+                    contentParser.skipChildren()
+                }
+            }
+        }
+        if (type != "notification") {
+            throw IllegalArgumentException("Unsupported Request type:$type")
+        }
+        return message ?: throw IllegalArgumentException("Request params not present")
+    }
+
+    private fun parseNotificationMessage(contentParser: XContentParser): NotificationMessage? {
+        var refTag: String? = null
+        var title: String? = null
+        var textDescription: String? = null
+        var htmlDescription: String? = null
+        var textData: String? = null
+        var binaryData: String? = null
+        val recipients: MutableList<String> = mutableListOf()
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, contentParser.currentToken(), contentParser::getTokenLocation)
+        while (contentParser.nextToken() != XContentParser.Token.END_OBJECT) {
+            val fieldName = contentParser.currentName()
+            contentParser.nextToken()
+            when (fieldName) {
+                "refTag" -> refTag = contentParser.text()
+                "recipients" -> {
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, contentParser.currentToken(), contentParser::getTokenLocation)
+                    while (contentParser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        recipients.add(contentParser.text())
+                    }
+                }
+                "title" -> title = contentParser.text()
+                "description" -> {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, contentParser.currentToken(), contentParser::getTokenLocation)
+                    while (contentParser.nextToken() != XContentParser.Token.END_OBJECT) {
+                        val descriptionType = contentParser.currentName()
+                        contentParser.nextToken()
+                        when (descriptionType) {
+                            "text" -> textDescription = contentParser.text()
+                            "html" -> htmlDescription = contentParser.text()
+                        }
+                    }
+                }
+                "data" -> {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, contentParser.currentToken(), contentParser::getTokenLocation)
+                    while (contentParser.nextToken() != XContentParser.Token.END_OBJECT) {
+                        val dataType = contentParser.currentName()
+                        contentParser.nextToken()
+                        when (dataType) {
+                            "base64" -> binaryData = contentParser.text()
+                            "text" -> textData = contentParser.text()
+                        }
+                    }
+                }
+                else -> {
+                    contentParser.skipChildren()
+                }
+            }
+        }
+        refTag = refTag ?: "noRef"
+        if (recipients.isEmpty()) {
+            throw IllegalArgumentException("Empty recipient list")
+        }
+        title ?: throw IllegalArgumentException("Title field not present")
+        if (textDescription == null && htmlDescription == null) {
+            throw IllegalArgumentException("Both text and html description not present")
+        }
+        if (binaryData != null && textData != null) {
+            throw IllegalArgumentException("Both text and binary data present")
+        }
+        return NotificationMessage(refTag, title, recipients.toList(), textDescription, htmlDescription, binaryData, textData)
+    }
+}

--- a/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/resthandler/SendRestHandler.kt
+++ b/notification/src/main/kotlin/com/amazon/opendistroforelasticsearch/notification/resthandler/SendRestHandler.kt
@@ -17,6 +17,7 @@
 package com.amazon.opendistroforelasticsearch.notification.resthandler
 
 import com.amazon.opendistroforelasticsearch.notification.NotificationPlugin.Companion.PLUGIN_BASE_URI
+import com.amazon.opendistroforelasticsearch.notification.NotificationPlugin.Companion.PLUGIN_NAME
 import com.amazon.opendistroforelasticsearch.notification.action.SendAction
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.client.node.NodeClient
@@ -44,7 +45,7 @@ class SendRestHandler : BaseRestHandler() {
     @Throws(IOException::class)
     @Suppress("SpreadOperator") // There is no way around dealing with java vararg without spread operator.
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
-        log.debug("prepareRequest called")
+        log.debug("$PLUGIN_NAME:prepareRequest")
         return RestChannelConsumer {
             SendAction(request, client, it).send()
         }


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Now the notification request is being parsed and validated for required parameters. on valid request, plugin responds with Success JSON data

Other minor changes:

1. Updated .gitignore with Eclipse files
2. Using $PLUGIN_NAME for logging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
