### PR TITLE
Report Definition Details UI Changes

### DIFF
--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -106,26 +106,23 @@ export function ReportDefinitionDetails(props) {
   };
 
   useEffect(() => {
-    props.setBreadcrumbs([
-      {
-        text: 'Reporting',
-        href: '#',
-      },
-      {
-        text: 'Report definition details',
-        href: `#/report_definition_details/${props.match['params']['reportDefinitionId']}`,
-      },
-      {
-        text: `${props.match['params']['reportDefinitionId']}`,
-      },
-    ]);
     const { httpClient } = props;
+    console.log("props is", props);
     httpClient
       .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
       .then((response) => {
         handleReportDefinitionDetails(
           getReportDefinitionDetailsMetadata(response)
         );
+        props.setBreadcrumbs([
+          {
+            text: 'Reporting',
+            href: '#',
+          },
+          {
+            text: `Report definition details: ${response.report_definition.report_params.report_name}`,
+          },
+        ]);
       })
       .catch((error) => {
         console.error('error when getting report definition details:', error);
@@ -137,7 +134,7 @@ export function ReportDefinitionDetails(props) {
     formatUpper = fileFormatsUpper[formatUpper];
     return (
       <EuiLink>
-        {formatUpper}
+        {formatUpper + ' '}
         <EuiIcon type="importAction" />
       </EuiLink>
     );
@@ -165,6 +162,19 @@ export function ReportDefinitionDetails(props) {
       }
     }
   };
+
+  const deleteReportDefinition = () => {
+    const { httpClient } = props;
+    httpClient
+      .delete(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
+      .then((response) => {
+        console.log("report definition deleted successfully");
+        window.location.assign(`opendistro_kibana_reports#/`);
+      })
+      .catch((error) => {
+        console.log("error when deleting report definition:", error);
+      })
+  }
 
   const includeReportAsAttachmentString = reportDefinitionDetails.includeReportAsAttachment
     ? 'True'
@@ -194,7 +204,7 @@ export function ReportDefinitionDetails(props) {
               gutterSize="l"
             >
               <EuiFlexItem grow={false}>
-                <EuiButton color={'danger'}>Delete</EuiButton>
+                <EuiButton color={'danger'} onClick={deleteReportDefinition}>Delete</EuiButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 {scheduleOrOnDemandDefinition(reportDefinitionDetails)}

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -107,7 +107,6 @@ export function ReportDefinitionDetails(props) {
 
   useEffect(() => {
     const { httpClient } = props;
-    console.log("props is", props);
     httpClient
       .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
       .then((response) => {
@@ -168,7 +167,6 @@ export function ReportDefinitionDetails(props) {
     httpClient
       .delete(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
       .then((response) => {
-        console.log("report definition deleted successfully");
         window.location.assign(`opendistro_kibana_reports#/`);
       })
       .catch((error) => {

--- a/kibana-reports/server/routes/reportDefinition.ts
+++ b/kibana-reports/server/routes/reportDefinition.ts
@@ -289,13 +289,15 @@ export default function (router: IRouter) {
 
       try {
         // retrieve report definition
-        const reportDefinition: ReportDefinitionSchemaType = await context.core.elasticsearch.dataClient.callAsCurrentUser(
+        const getReportDefinitionResp = await context.core.elasticsearch.dataClient.callAsCurrentUser(
           'get',
           {
             index: CONFIG_INDEX_NAME.reportDefinition,
             id: reportDefinitionId,
           }
         );
+        const reportDefinition: ReportDefinitionSchemaType =
+          getReportDefinitionResp._source.report_definition;
         const triggerType = reportDefinition.trigger.trigger_type;
         let esResp;
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Fixed breadcrumbs to display report definition name 
* Added space between file format and download icon
* Link to `Edit` page works 
* `Delete` button is hooked in and works 

TODO: 
* Fix `Edit report definition` page to pre-populate fields correctly after schema change
* Hook in `Generate report` button after schema change (pending fix from @zhongnansu)  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
