### PR TITLE
[UI] Align create report definition UI to schema & API refactor

### DIFF
--- a/kibana-reports/public/components/main/main_utils.tsx
+++ b/kibana-reports/public/components/main/main_utils.tsx
@@ -84,7 +84,7 @@ export const addReportDefinitionsTableContent = (data: any) => {
       id: item._id,
       reportName: reportParams.report_name,
       type: trigger.trigger_type,
-      owner: 'davidcui', // Todo: replace
+      owner: `\u2014`, // Todo: replace
       source: reportParams.report_source,
       baseUrl: reportParams.core_params.base_url,
       lastUpdated: reportDefinition.last_updated,

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -42,20 +42,6 @@ export function ReportDefinitionDetails(props) {
     setReportDefinitionDetails(e);
   };
 
-  // const readableTimeRange = (data) => {
-  //   let timeRangeString = '';
-  //   if (
-  //     data['trigger']['trigger_params']['schedule']['interval']['unit'] ===
-  //     'DAYS'
-  //   ) {
-  //     timeRangeString +=
-  //       'Every ' +
-  //       data['trigger']['trigger_params']['schedule']['interval']['period'] +
-  //       ' days';
-  //   }
-  //   return timeRangeString;
-  // };
-
   const getReportDefinitionDetailsMetadata = (data) => {
     const reportDefinition: ReportDefinitionSchemaType = data.report_definition;
     const reportParams = reportDefinition.report_params;
@@ -72,11 +58,6 @@ export function ReportDefinitionDetails(props) {
       readableUpdatedDate.toDateString() +
       ' ' +
       readableUpdatedDate.toLocaleTimeString();
-
-    // let timeRangeDisplay = `\u2014`;
-    // if (trigger.trigger_type === 'Schedule') {
-    //   readableTimeRange(data);
-    // }
 
     let reportDefinitionDetails = {
       name: reportParams.report_name,

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -42,19 +42,19 @@ export function ReportDefinitionDetails(props) {
     setReportDefinitionDetails(e);
   };
 
-  const readableTimeRange = (data) => {
-    let timeRangeString = '';
-    if (
-      data['trigger']['trigger_params']['schedule']['interval']['unit'] ===
-      'DAYS'
-    ) {
-      timeRangeString +=
-        'Every ' +
-        data['trigger']['trigger_params']['schedule']['interval']['period'] +
-        ' days';
-    }
-    return timeRangeString;
-  };
+  // const readableTimeRange = (data) => {
+  //   let timeRangeString = '';
+  //   if (
+  //     data['trigger']['trigger_params']['schedule']['interval']['unit'] ===
+  //     'DAYS'
+  //   ) {
+  //     timeRangeString +=
+  //       'Every ' +
+  //       data['trigger']['trigger_params']['schedule']['interval']['period'] +
+  //       ' days';
+  //   }
+  //   return timeRangeString;
+  // };
 
   const getReportDefinitionDetailsMetadata = (data) => {
     const reportDefinition: ReportDefinitionSchemaType = data.report_definition;
@@ -73,10 +73,10 @@ export function ReportDefinitionDetails(props) {
       ' ' +
       readableUpdatedDate.toLocaleTimeString();
 
-    let timeRangeDisplay = `\u2014`;
-    if (trigger.trigger_type === 'Schedule') {
-      readableTimeRange(data);
-    }
+    // let timeRangeDisplay = `\u2014`;
+    // if (trigger.trigger_type === 'Schedule') {
+    //   readableTimeRange(data);
+    // }
 
     let reportDefinitionDetails = {
       name: reportParams.report_name,
@@ -170,9 +170,9 @@ export function ReportDefinitionDetails(props) {
         window.location.assign(`opendistro_kibana_reports#/`);
       })
       .catch((error) => {
-        console.log("error when deleting report definition:", error);
-      })
-  }
+        console.log('error when deleting report definition:', error);
+      });
+  };
 
   const includeReportAsAttachmentString = reportDefinitionDetails.includeReportAsAttachment
     ? 'True'
@@ -202,7 +202,9 @@ export function ReportDefinitionDetails(props) {
               gutterSize="l"
             >
               <EuiFlexItem grow={false}>
-                <EuiButton color={'danger'} onClick={deleteReportDefinition}>Delete</EuiButton>
+                <EuiButton color={'danger'} onClick={deleteReportDefinition}>
+                  Delete
+                </EuiButton>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 {scheduleOrOnDemandDefinition(reportDefinitionDetails)}

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -19,7 +19,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiButton,
-  EuiPage,
   EuiTitle,
   EuiPageBody,
   EuiSpacer,
@@ -29,33 +28,101 @@ import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
 import { generateReport } from '../../main/main_utils';
 
-export const TIMEZONE_OPTIONS = [
-  { value: -4, text: 'EDT -04:00' },
-  { value: -5, text: 'CDT -05:00' },
-  { value: -6, text: 'MDT -06:00' },
-  { value: -7, text: 'MST/PDT -07:00' },
-  { value: -8, text: 'AKDT -08:00' },
-  { value: -10, text: 'HST -10:00' },
-];
-
 export let defaultUrl;
+interface reportParamsType {
+  report_name: string;
+  report_source: string;
+  description: string;
+  core_params: visualReportParams | dataReportParams;
+}
+interface visualReportParams {
+  base_url: string;
+  report_format: string;
+  time_duration: string;
+}
+
+interface dataReportParams {
+  saved_search_id: number;
+  base_url: string;
+  report_format: string;
+  time_duration: string;
+}
+interface triggerType {
+  trigger_type: string;
+  trigger_params?: any;
+}
+
+export interface TriggerParamsType {
+  schedule_type: string;
+  schedule: Recurring | Cron;
+  enabled_time: number;
+  enabled: boolean;
+}
+
+interface Recurring {
+  interval: {
+    period: number;
+    unit: string;
+    start_time: number;
+  };
+}
+
+interface Cron {
+  cron: {
+    cron_expression: string;
+    time_zone: string;
+  };
+}
+
+export interface reportDefinitionParams {
+  report_params: reportParamsType;
+  delivery?: any;
+  trigger: triggerType;
+}
+
+export interface timeRangeParams {
+  timeFrom: Date;
+  timeTo: Date;
+}
 
 export function CreateReport(props) {
-  let createReportDefinitionRequest = {
-    report_name: '',
-    report_source: '',
-    report_type: '',
-    description: '',
+  let createReportDefinitionRequest: reportDefinitionParams = {
     report_params: {
-      url: ``,
-      report_format: '',
+      report_name: '',
+      report_source: '',
+      description: '',
+      core_params: {
+        base_url: '',
+        report_format: '',
+        time_duration: '',
+      },
     },
-    delivery: {},
-    trigger: {},
+    //TODO: add this field back when the notification module became available
+    // delivery: {},
+    trigger: {
+      trigger_type: '',
+    },
   };
 
-  const createNewReportDefinition = async (metadata) => {
+  let timeRange = {
+    timeFrom: new Date(),
+    timeTo: new Date(),
+  };
+
+  const createNewReportDefinition = async (
+    metadata: reportDefinitionParams,
+    timeRange: timeRangeParams
+  ) => {
     const { httpClient } = props;
+    //TODO: need better handle
+    if (
+      metadata.trigger.trigger_type === 'On demand' &&
+      metadata.trigger.trigger_params !== undefined
+    ) {
+      delete metadata.trigger.trigger_params;
+    }
+
+    console.log(metadata);
     httpClient
       .post('../api/reporting/reportDefinition', {
         body: JSON.stringify(metadata),
@@ -64,21 +131,15 @@ export function CreateReport(props) {
         },
       })
       .then(async (resp) => {
-        if (
-          metadata['trigger']['trigger_params']['schedule_type'] === 'Now' ||
-          metadata['trigger']['trigger_type'] === 'On demand'
-        ) {
+        //TODO: consider handle the on demand report generation from server side instead
+        if (metadata.trigger.trigger_type === 'On demand') {
           let onDemandDownloadMetadata = {
-            report_name: metadata['report_name'],
-            report_source: metadata['report_source'],
-            report_type: metadata['report_type'],
-            description: metadata['description'],
-            report_params: {
-              url: metadata['report_params']['url'],
-              window_width: 1440,
-              window_height: 2560,
-              report_format: metadata['report_params']['report_format'],
-            },
+            query_url: `${
+              metadata.report_params.core_params.base_url
+            }?_g=(time:(from:'${timeRange.timeFrom.toISOString()}',to:'${timeRange.timeTo.toISOString()}'))`,
+            time_from: timeRange.timeFrom.valueOf(),
+            time_to: timeRange.timeTo.valueOf(),
+            report_definition: metadata,
           };
           generateReport(onDemandDownloadMetadata, httpClient);
         }
@@ -113,6 +174,7 @@ export function CreateReport(props) {
           edit={false}
           reportDefinitionRequest={createReportDefinitionRequest}
           httpClientProps={props['httpClient']}
+          timeRange={timeRange}
         />
         <EuiSpacer />
         <ReportTrigger
@@ -120,10 +182,10 @@ export function CreateReport(props) {
           reportDefinitionRequest={createReportDefinitionRequest}
         />
         <EuiSpacer />
-        <ReportDelivery
+        {/* <ReportDelivery
           edit={false}
           reportDefinitionRequest={createReportDefinitionRequest}
-        />
+        /> */}
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
@@ -139,7 +201,10 @@ export function CreateReport(props) {
             <EuiButton
               fill={true}
               onClick={() =>
-                createNewReportDefinition(createReportDefinitionRequest)
+                createNewReportDefinition(
+                  createReportDefinitionRequest,
+                  timeRange
+                )
               }
             >
               Create

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -113,7 +113,10 @@ export function CreateReport(props) {
     metadata: reportDefinitionParams,
     timeRange: timeRangeParams
   ) => {
+    // TODO: temporarily remove delivery from request body, since integration with notification module is needed
+    delete metadata.delivery;
     const { httpClient } = props;
+
     //TODO: need better handle
     if (
       metadata.trigger.trigger_type === 'On demand' &&
@@ -122,7 +125,6 @@ export function CreateReport(props) {
       delete metadata.trigger.trigger_params;
     }
 
-    console.log(metadata);
     httpClient
       .post('../api/reporting/reportDefinition', {
         body: JSON.stringify(metadata),
@@ -182,10 +184,10 @@ export function CreateReport(props) {
           reportDefinitionRequest={createReportDefinitionRequest}
         />
         <EuiSpacer />
-        {/* <ReportDelivery
+        <ReportDelivery
           edit={false}
           reportDefinitionRequest={createReportDefinitionRequest}
-        /> */}
+        />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -124,7 +124,6 @@ export function CreateReport(props) {
     ) {
       delete metadata.trigger.trigger_params;
     }
-
     httpClient
       .post('../api/reporting/reportDefinition', {
         body: JSON.stringify(metadata),

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -101,8 +101,6 @@ function TimeRangeSelect(props) {
     );
     setIsLoading(true);
     startLoading();
-
-    // parseTimeRange(start, end, reportDefinitionRequest);
   };
 
   const parseTimeRange = (start, end, reportDefinitionRequest) => {

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -47,6 +47,10 @@ import dateMath from '@elastic/datemath';
 import Showdown from 'showdown';
 import ReactMde from 'react-mde';
 import 'react-mde/lib/styles/css/react-mde-all.css';
+import {
+  reportDefinitionParams,
+  timeRangeParams,
+} from '../create/create_report_definition';
 
 const isValidTimeRange = (
   timeRangeMoment: number | moment.Moment,
@@ -67,13 +71,19 @@ const isValidTimeRange = (
   }
 };
 
-function TimeRangeSelect() {
+function TimeRangeSelect(props) {
+  const { reportDefinitionRequest, timeRange } = props;
+
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [start, setStart] = useState('now-30m');
   const [end, setEnd] = useState('now');
   const [isPaused, setIsPaused] = useState(true);
   const [refreshInterval, setRefreshInterval] = useState();
+
+  useEffect(() => {
+    parseTimeRange(start, end, reportDefinitionRequest);
+  }, [start, end]);
 
   const onTimeChange = ({ start, end }) => {
     const recentlyUsedRange = recentlyUsedRanges.filter((recentlyUsedRange) => {
@@ -91,6 +101,17 @@ function TimeRangeSelect() {
     );
     setIsLoading(true);
     startLoading();
+
+    // parseTimeRange(start, end, reportDefinitionRequest);
+  };
+
+  const parseTimeRange = (start, end, reportDefinitionRequest) => {
+    timeRange.timeFrom = dateMath.parse(start);
+    timeRange.timeTo = dateMath.parse(end);
+    const timeDuration = moment.duration(
+      dateMath.parse(end).diff(dateMath.parse(start))
+    );
+    reportDefinitionRequest.report_params.core_params.time_duration = timeDuration.toISOString();
   };
 
   const onRefresh = ({ start, end, refreshInterval }) => {
@@ -141,12 +162,21 @@ function TimeRangeSelect() {
   );
 }
 
-export function ReportSettings(props) {
+type ReportSettingProps = {
+  edit: boolean;
+  editDefinitionId: string;
+  reportDefinitionRequest: reportDefinitionParams;
+  httpClientProps: any;
+  timeRange: timeRangeParams;
+};
+
+export function ReportSettings(props: ReportSettingProps) {
   const {
     edit,
     editDefinitionId,
     reportDefinitionRequest,
     httpClientProps,
+    timeRange,
   } = props;
 
   const [reportName, setReportName] = useState('');
@@ -164,7 +194,7 @@ export function ReportSettings(props) {
   const [savedSearchSourceSelect, setSavedSearchSourceSelect] = useState('');
   const [savedSearches, setSavedSearches] = useState([]);
 
-  const [fileFormat, setFileFormat] = useState('pdfFormat');
+  const [fileFormat, setFileFormat] = useState('pdf');
 
   const [savedSearchFileFormat, setSavedSearchFileFormat] = useState(
     'csvFormat'
@@ -186,34 +216,35 @@ export function ReportSettings(props) {
     target: { value: React.SetStateAction<string> };
   }) => {
     setReportName(e.target.value);
-    reportDefinitionRequest['report_name'] = e.target.value.toString();
+    reportDefinitionRequest.report_params.report_name = e.target.value.toString();
   };
 
   const handleReportDescription = (e: {
     target: { value: React.SetStateAction<string> };
   }) => {
     setReportDescription(e.target.value);
-    reportDefinitionRequest['description'] = e.target.value.toString();
+    reportDefinitionRequest.report_params.description = e.target.value.toString();
   };
 
   const handleReportSource = (e: React.SetStateAction<string>) => {
     setReportSourceId(e);
     if (e === 'dashboardReportSource') {
-      reportDefinitionRequest['report_source'] = 'Dashboard';
-      reportDefinitionRequest['report_params']['url'] =
+      reportDefinitionRequest.report_params.report_source = 'Dashboard';
+      reportDefinitionRequest.report_params.core_params.base_url =
         getDashboardBaseUrlCreate() + dashboards[0].value;
     } else if (e === 'visualizationReportSource') {
-      reportDefinitionRequest['report_source'] = 'Visualization';
-      reportDefinitionRequest['report_params']['url'] =
+      reportDefinitionRequest.report_params.report_source = 'Visualization';
+      reportDefinitionRequest.report_params.core_params.base_url =
         getVisualizationBaseUrlCreate() + visualizations[0].value;
     }
+    // TODO: handle data report
   };
 
   const handleDashboardSelect = (e: {
     target: { value: React.SetStateAction<string> };
   }) => {
     setDashboardSourceSelect(e.target.value);
-    reportDefinitionRequest['report_params']['url'] =
+    reportDefinitionRequest.report_params.core_params.base_url =
       getDashboardBaseUrlCreate() + e.target.value;
   };
 
@@ -221,7 +252,7 @@ export function ReportSettings(props) {
     target: { value: React.SetStateAction<string> };
   }) => {
     setVisualizationSourceSelect(e.target.value);
-    reportDefinitionRequest['report_params']['url'] =
+    reportDefinitionRequest.report_params.core_params.base_url =
       getVisualizationBaseUrlCreate() + e.target.value;
   };
 
@@ -233,11 +264,7 @@ export function ReportSettings(props) {
 
   const handleFileFormat = (e: React.SetStateAction<string>) => {
     setFileFormat(e);
-    if (e === 'pdfFormat') {
-      reportDefinitionRequest['report_params']['report_format'] = 'pdf';
-    } else if (e === 'pngFormat') {
-      reportDefinitionRequest['report_params']['report_format'] = 'png';
-    }
+    reportDefinitionRequest.report_params.core_params.report_format = e.toString();
   };
 
   const converter = new Showdown.Converter({
@@ -351,7 +378,10 @@ export function ReportSettings(props) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        <TimeRangeSelect />
+        <TimeRangeSelect
+          timeRange={timeRange}
+          reportDefinitionRequest={reportDefinitionRequest}
+        />
         <EuiSpacer />
         <PDFandPNGFileFormats />
         <EuiSpacer size="s" />
@@ -372,7 +402,10 @@ export function ReportSettings(props) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        <TimeRangeSelect />
+        <TimeRangeSelect
+          timeRange={timeRange}
+          reportDefinitionRequest={reportDefinitionRequest}
+        />
         <EuiSpacer />
         <PDFandPNGFileFormats />
         <EuiSpacer size="s" />
@@ -393,7 +426,10 @@ export function ReportSettings(props) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        <TimeRangeSelect />
+        <TimeRangeSelect
+          timeRange={timeRange}
+          reportDefinitionRequest={reportDefinitionRequest}
+        />
         <EuiSpacer />
         <EuiFormRow label="File format">
           <EuiText>
@@ -404,7 +440,7 @@ export function ReportSettings(props) {
     );
   };
 
-  let displayDashboardSelect =
+  const displayDashboardSelect =
     reportSourceId === 'dashboardReportSource' ? (
       <ReportSourceDashboard />
     ) : null;
@@ -483,13 +519,14 @@ export function ReportSettings(props) {
   const setDefaultEditValues = async (response, reportSourceOptions) => {
     setReportName(response.report_name);
     setReportDescription(response.description);
-    reportDefinitionRequest.report_name = response.report_name;
-    reportDefinitionRequest.description = response.description;
+    reportDefinitionRequest.report_params.report_name = response.report_name;
+    reportDefinitionRequest.report_params.description = response.description;
     reportDefinitionRequest.report_params = response.report_params;
     REPORT_SOURCE_RADIOS.map((radio) => {
       if (radio.label === response.report_source) {
         setReportSourceId(radio.id);
-        reportDefinitionRequest.report_source = response.report_source;
+        reportDefinitionRequest.report_params.report_source =
+          response.report_source;
       }
     });
     setDefaultFileFormat(response['report_params']['report_format']);
@@ -519,6 +556,7 @@ export function ReportSettings(props) {
       visualizations: [],
       savedSearch: [],
     };
+    reportDefinitionRequest.report_params.core_params.report_format = fileFormat;
     await httpClientProps
       .get('../api/reporting/getReportSource/dashboard')
       .then(async (response) => {
@@ -529,7 +567,8 @@ export function ReportSettings(props) {
         handleDashboards(dashboardOptions);
         if (!edit) {
           setDashboardSourceSelect(dashboardOptions[0].value);
-          reportDefinitionRequest['report_params']['url'] =
+          reportDefinitionRequest.report_params.report_source = 'Dashboard';
+          reportDefinitionRequest['report_params']['core_params']['base_url'] =
             getDashboardBaseUrlCreate() +
             response['hits']['hits'][0]['_id'].substring(10);
         }
@@ -537,8 +576,6 @@ export function ReportSettings(props) {
       .catch((error) => {
         console.log('error when fetching dashboards:', error);
       });
-    reportDefinitionRequest['report_params']['report_format'] = 'pdf';
-    reportDefinitionRequest['report_source'] = 'Dashboard';
 
     await httpClientProps
       .get('../api/reporting/getReportSource/visualization')

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -30,11 +30,11 @@ export const REPORT_SOURCE_RADIOS = [
 
 export const PDF_PNG_FILE_FORMAT_OPTIONS = [
   {
-    id: 'pdfFormat',
+    id: 'pdf',
     label: 'PDF',
   },
   {
-    id: 'pngFormat',
+    id: 'png',
     label: 'PNG',
   },
 ];

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -72,7 +72,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
   const [scheduleType, setScheduleType] = useState('recurringOption');
   //TODO: should read local timezone and display
   const [timezone, setTimezone] = useState(TIMEZONE_OPTIONS[0].value);
-  // const [futureDateTimeSelect, setFutureDateTimeSelect] = useState(moment());
   const [scheduleRecurringFrequency, setScheduleRecurringFrequency] = useState(
     'daily'
   );
@@ -97,12 +96,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
   const handleScheduleType = (e: React.SetStateAction<string>) => {
     setScheduleType(e);
   };
-
-  // const handleFutureDateTimeSelect = (
-  //   e: React.SetStateAction<moment.Moment>
-  // ) => {
-  //   setFutureDateTimeSelect(e);
-  // };
 
   const handleTimezone = (e) => {
     setTimezone(e.target.value);
@@ -166,22 +159,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
       </div>
     );
   };
-
-  // const ScheduleTriggerFutureDate = () => {
-  //   return (
-  //     <div>
-  //       <EuiFormRow label="Request time">
-  //         <EuiDatePicker
-  //           showTimeSelect
-  //           selected={futureDateTimeSelect}
-  //           onChange={handleFutureDateTimeSelect}
-  //         />
-  //       </EuiFormRow>
-  //       <EuiSpacer />
-  //       <TimezoneSelect />
-  //     </div>
-  //   );
-  // };
 
   const RequestTime = () => {
     useEffect(() => {
@@ -439,11 +416,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
   };
 
   const ScheduleTrigger = () => {
-    // const display_future_date =
-    //   scheduleRequestTime === 'futureDateOption' ? (
-    //     <ScheduleTriggerFutureDate />
-    //   ) : null;
-
     const display_recurring =
       scheduleType === 'recurringOption' ? <ScheduleTriggerRecurring /> : null;
 
@@ -474,7 +446,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        {/* {display_future_date} */}
         {display_recurring}
         {display_cron}
       </div>

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -46,7 +46,6 @@ import {
   WEEKLY_CHECKBOX_OPTIONS,
   MONTHLY_ON_THE_OPTIONS,
   MONTHLY_DAY_SELECT_OPTIONS,
-  SCHEDULE_OPTION_MAP,
   TRIGGER_TYPE_OPTIONS,
   SCHEDULE_TYPE_OPTIONS,
   TIMEZONE_OPTIONS,
@@ -67,9 +66,9 @@ export function ReportTrigger(props: ReportTriggerProps) {
     httpClientProps,
   } = props;
 
-  const [reportTriggerType, setReportTriggerType] = useState('onDemandOption');
+  const [reportTriggerType, setReportTriggerType] = useState('On demand');
 
-  const [scheduleType, setScheduleType] = useState('recurringOption');
+  const [scheduleType, setScheduleType] = useState('Recurring');
   //TODO: should read local timezone and display
   const [timezone, setTimezone] = useState(TIMEZONE_OPTIONS[0].value);
   const [scheduleRecurringFrequency, setScheduleRecurringFrequency] = useState(
@@ -417,10 +416,10 @@ export function ReportTrigger(props: ReportTriggerProps) {
 
   const ScheduleTrigger = () => {
     const display_recurring =
-      scheduleType === 'recurringOption' ? <ScheduleTriggerRecurring /> : null;
+      scheduleType === 'Recurring' ? <ScheduleTriggerRecurring /> : null;
 
     const display_cron =
-      scheduleType === 'cronBasedOption' ? <CronExpression /> : null;
+      scheduleType === 'Cron based' ? <CronExpression /> : null;
 
     useEffect(() => {
       // Set default trigger_type
@@ -485,9 +484,9 @@ export function ReportTrigger(props: ReportTriggerProps) {
   };
 
   const schedule =
-    reportTriggerType === 'scheduleOption' ? <ScheduleTrigger /> : null;
+    reportTriggerType === 'Schedule' ? <ScheduleTrigger /> : null;
 
-  const alert = reportTriggerType === 'alertOption' ? <AlertTrigger /> : null;
+  const alert = reportTriggerType === 'Alerting' ? <AlertTrigger /> : null;
 
   const defaultEditTriggerType = (trigger_type) => {
     let index = 0;

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
@@ -13,18 +13,18 @@
  * permissions and limitations under the License.
  */
 
-export const REPORT_TYPE_OPTIONS = [
+export const TRIGGER_TYPE_OPTIONS = [
   {
     id: 'onDemandOption',
     label: 'On demand',
   },
   {
     id: 'scheduleOption',
-    label: 'Schedule based',
+    label: 'Schedule',
   },
 ];
 
-export const SCHEDULE_REQUEST_TIME_OPTIONS = [
+export const SCHEDULE_TYPE_OPTIONS = [
   {
     id: 'recurringOption',
     label: 'Recurring',
@@ -56,12 +56,16 @@ export const SCHEDULE_RECURRING_OPTIONS = [
 
 export const INTERVAL_TIME_PERIODS = [
   {
-    value: 'minutes',
+    value: 'MINUTES',
     text: 'Minutes',
   },
   {
-    value: 'hours',
+    value: 'HOURS',
     text: 'Hours',
+  },
+  {
+    value: 'DAYS',
+    text: 'Days',
   },
 ];
 
@@ -167,13 +171,19 @@ export const MONTHLY_DAY_SELECT_OPTIONS = [
 ];
 
 export const SCHEDULE_OPTION_MAP = {
-  nowOption: 'Now',
   futureDateOption: 'Future date',
   recurringOption: 'Recurring',
   cronBasedOption: 'Cron',
 };
 
-export const TRIGGER_OPTION_MAP = {
+export const TRIGGER_TYPE = {
   scheduleOption: 'Schedule',
   alertOption: 'Alert',
+  onDemandOption: 'On demand',
 };
+
+//TODO: need to figure out what kind of timezone to use for both display and scheduler
+export const TIMEZONE_OPTIONS = [
+  { value: 'EST', text: 'EST US/Eastern' },
+  { value: 'PST8PDT', text: 'PST US/Pacific' },
+];

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
@@ -171,7 +171,6 @@ export const MONTHLY_DAY_SELECT_OPTIONS = [
 ];
 
 export const SCHEDULE_OPTION_MAP = {
-  futureDateOption: 'Future date',
   recurringOption: 'Recurring',
   cronBasedOption: 'Cron',
 };

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
@@ -15,22 +15,22 @@
 
 export const TRIGGER_TYPE_OPTIONS = [
   {
-    id: 'onDemandOption',
+    id: 'On demand',
     label: 'On demand',
   },
   {
-    id: 'scheduleOption',
+    id: 'Schedule',
     label: 'Schedule',
   },
 ];
 
 export const SCHEDULE_TYPE_OPTIONS = [
   {
-    id: 'recurringOption',
+    id: 'Recurring',
     label: 'Recurring',
   },
   {
-    id: 'cronBasedOption',
+    id: 'Cron based',
     label: 'Cron based',
   },
 ];
@@ -170,19 +170,8 @@ export const MONTHLY_DAY_SELECT_OPTIONS = [
   },
 ];
 
-export const SCHEDULE_OPTION_MAP = {
-  recurringOption: 'Recurring',
-  cronBasedOption: 'Cron',
-};
-
-export const TRIGGER_TYPE = {
-  scheduleOption: 'Schedule',
-  alertOption: 'Alert',
-  onDemandOption: 'On demand',
-};
-
 //TODO: need to figure out what kind of timezone to use for both display and scheduler
 export const TIMEZONE_OPTIONS = [
-  { value: 'EST', text: 'EST US/Eastern' },
   { value: 'PST8PDT', text: 'PST US/Pacific' },
+  { value: 'EST', text: 'EST US/Eastern' },
 ];

--- a/kibana-reports/server/model/index.ts
+++ b/kibana-reports/server/model/index.ts
@@ -60,7 +60,7 @@ export const intervalSchema = schema.object({
 export const cronSchema = schema.object({
   cron: schema.object({
     expression: schema.string(),
-    time_zone: schema.string(),
+    timezone: schema.string(),
   }),
 });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enable create report definition with
   - on demand
   - recurring
     - daily/interval
     - cron based
- temporarily comment out delivery in create report definition page
- remove future date option since there is no support on server side

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
