### PR TITLE
Edit Report Definition Fix & Refactor

### DIFF
--- a/kibana-reports/public/components/app.tsx
+++ b/kibana-reports/public/components/app.tsx
@@ -117,6 +117,7 @@ export const OpendistroKibanaReportsApp = ({
                         title="Edit Report Definition"
                         httpClient={http}
                         {...props}
+                        setBreadcrumbs={chrome.setBreadcrumbs}
                       />
                     )}
                   />

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -28,9 +28,7 @@ import { ReportSettings } from '../report_settings';
 import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
 import { generateReport } from '../../main/main_utils';
-import { Request } from 'selenium-webdriver/http';
 
-export let defaultUrl;
 interface reportParamsType {
   report_name: string;
   report_source: string;

--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -31,19 +31,30 @@ import { ReportTrigger } from '../report_trigger';
 export function EditReportDefinition(props) {
   const reportDefinitionId = props['match']['params']['reportDefinitionId'];
   let editReportDefinitionRequest = {
-    report_name: '',
-    report_source: '',
-    report_type: '',
-    description: '',
     report_params: {
-      url: '',
-      report_format: '',
+      report_name: '',
+      report_source: '',
+      description: '',
+      core_params: {
+        base_url: '',
+        report_format: '',
+        time_duration: '',
+      },
     },
-    delivery: {},
-    trigger: {},
+    //TODO: add this field back when the notification module became available
+    // delivery: {},
+    trigger: {
+      trigger_type: '',
+    },
+  };
+
+  let timeRange = {
+    timeFrom: new Date(),
+    timeTo: new Date(),
   };
 
   const editReportDefinition = async (metadata) => {
+    delete metadata.delivery;
     const { httpClient } = props;
     httpClient
       .put(`../api/reporting/reportDefinitions/${reportDefinitionId}`, {
@@ -58,6 +69,33 @@ export function EditReportDefinition(props) {
       });
   };
 
+  useEffect(() => {
+    const { httpClient } = props;
+    httpClient
+      .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
+      .then((response) => {
+        props.setBreadcrumbs([
+          {
+            text: 'Reporting',
+            href: '#',
+          },
+          {
+            text: `Report definition details: ${response.report_definition.report_params.report_name}`,
+            href: `#/report_definition_details/${reportDefinitionId}`,
+          },
+          {
+            text: `Edit report definition: ${response.report_definition.report_params.report_name}`,
+          },
+        ]);
+      })
+      .catch((error) => {
+        console.error(
+          'error when loading edit report definition page: ',
+          error
+        );
+      });
+  }, []);
+
   return (
     <EuiPage>
       <EuiPageBody>
@@ -70,6 +108,7 @@ export function EditReportDefinition(props) {
           editDefinitionId={reportDefinitionId}
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}
+          timeRange={timeRange}
         />
         <EuiSpacer />
         <ReportTrigger
@@ -77,6 +116,7 @@ export function EditReportDefinition(props) {
           editDefinitionId={reportDefinitionId}
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}
+          timeRange={timeRange}
         />
         <EuiSpacer />
         <ReportDelivery
@@ -84,6 +124,7 @@ export function EditReportDefinition(props) {
           editDefinitionId={reportDefinitionId}
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}
+          timeRange={timeRange}
         />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -14,24 +14,97 @@
  */
 
 export const parseInContextUrl = (url: string, parameter: string) => {
-  const info = url.split("?");
+  const info = url.split('?');
   if (parameter === 'id') {
-    return info[1].substring(
-      info[1].indexOf(":") + 1, 
-      info[1].length
-    );  
+    return info[1].substring(info[1].indexOf(':') + 1, info[1].length);
+  } else if (parameter === 'timeFrom') {
+    return info[2].substring(info[2].indexOf('=') + 1, info[2].length);
+  } else if (parameter === 'timeTo') {
+    return info[3].substring(info[3].indexOf('=') + 1, info[3].length);
   }
-  else if (parameter === 'timeFrom') {
-    return info[2].substring(
-      info[2].indexOf("=") + 1,
-      info[2].length
-    );  
-  }
-  else if (parameter === 'timeTo') {
-    return info[3].substring(
-      info[3].indexOf("=") + 1,
-      info[3].length
+  return 'error: invalid parameter';
+};
+
+export const getDashboardBaseUrlCreate = (
+  edit: boolean,
+  editDefinitionId: string
+) => {
+  let baseUrl = window.location.href;
+  if (edit) {
+    return baseUrl.replace(
+      `opendistro_kibana_reports#/edit/${editDefinitionId}`,
+      'dashboards#/view/'
     );
   }
-  return "error: invalid parameter";
-}
+  return baseUrl.replace(
+    'opendistro_kibana_reports#/create',
+    'kibana#/dashboard/'
+  );
+};
+
+export const getVisualizationBaseUrlCreate = (edit: boolean) => {
+  let baseUrl = window.location.href;
+  if (edit) {
+    return baseUrl.replace(
+      'opendistro_kibana_reports#/edit',
+      'kibana#/visualize/edit/'
+    );
+  }
+  return baseUrl.replace(
+    'opendistro_kibana_reports#/create',
+    'kibana#/visualize/edit/'
+  );
+};
+
+export const getSavedSearchBaseUrlCreate = (edit: boolean) => {
+  let baseUrl = window.location.href;
+  if (edit) {
+    return baseUrl.replace(
+      'opendistro_kibana_reports#/edit',
+      'kibana#/discover/'
+    );
+  }
+  return baseUrl.replace(
+    'opendistro_kibana_reports#/create',
+    'kibana#/discover/'
+  );
+};
+
+export const getDashboardOptions = (data) => {
+  let index;
+  let dashboard_options = [];
+  for (index = 0; index < data.length; ++index) {
+    let entry = {
+      value: data[index]['_id'].substring(10),
+      text: data[index]['_source']['dashboard']['title'],
+    };
+    dashboard_options.push(entry);
+  }
+  return dashboard_options;
+};
+
+export const getVisualizationOptions = (data: string | any[]) => {
+  let index;
+  let options = [];
+  for (index = 0; index < data.length; ++index) {
+    let entry = {
+      value: data[index]['_id'].substring(14),
+      text: data[index]['_source']['visualization']['title'],
+    };
+    options.push(entry);
+  }
+  return options;
+};
+
+export const getSavedSearchOptions = (data: string | any[]) => {
+  let index;
+  let options = [];
+  for (index = 0; index < data.length; ++index) {
+    let entry = {
+      value: data[index]['_id'].substring(7),
+      text: data[index]['_source']['search']['title'],
+    };
+    options.push(entry);
+  }
+  return options;
+};

--- a/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import moment from 'moment';
+import React, { useState, useEffect } from 'react';
+import { parseInContextUrl } from './report_settings_helpers';
+import dateMath from '@elastic/datemath';
+import { EuiFormRow, EuiSuperDatePicker } from '@elastic/eui';
+
+
+const isValidTimeRange = (
+  timeRangeMoment: number | moment.Moment,
+  limit: string
+) => {
+  if (limit === 'start') {
+    if (!timeRangeMoment || !timeRangeMoment.isValid()) {
+      throw new Error('Unable to parse start string');
+    }
+  } else if (limit === 'end') {
+    if (
+      !timeRangeMoment ||
+      !timeRangeMoment.isValid() ||
+      timeRangeMoment > moment()
+    ) {
+      throw new Error('Unable to parse end string');
+    }
+  }
+};
+
+export function TimeRangeSelect(props) {
+  const {
+    reportDefinitionRequest,
+    timeRange,
+    edit,
+    id,
+    httpClientProps,
+  } = props;
+
+  const [recentlyUsedRanges, setRecentlyUsedRanges] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [start, setStart] = useState('now-30m');
+  const [end, setEnd] = useState('now');
+  const [isPaused, setIsPaused] = useState(true);
+  const [refreshInterval, setRefreshInterval] = useState();
+
+  const setDefaultEditTimeRange = (duration) => {
+    let time_difference = moment.now() - duration;
+    const fromDate = new Date(time_difference);
+    parseTimeRange(fromDate, end, reportDefinitionRequest);
+    onTimeChange({ start: fromDate.toISOString(), end: end });
+  };
+
+  useEffect(() => {
+    // if we are coming from the in-context menu
+    if (window.location.href.indexOf('?') > -1) {
+      const url = window.location.href;
+      const timeFrom = parseInContextUrl(url, 'timeFrom');
+      const timeTo = parseInContextUrl(url, 'timeTo');
+      parseTimeRange(timeFrom, timeTo, reportDefinitionRequest);
+      onTimeChange({ start: timeFrom, end: timeTo });
+    } else {
+      if (edit) {
+        let duration;
+        httpClientProps
+          .get(`../api/reporting/reportDefinitions/${id}`)
+          .then(async (response: {}) => {
+            duration =
+              response.report_definition.report_params.core_params
+                .time_duration;
+            duration = moment.duration(duration);
+            setDefaultEditTimeRange(duration);
+          })
+          .catch((error) => {
+            console.error(
+              'error in fetching report definition details:',
+              error
+            );
+          });
+      } else {
+        parseTimeRange(start, end, reportDefinitionRequest);
+      }
+    }
+  }, []);
+
+  const onTimeChange = ({ start, end }) => {
+    const recentlyUsedRange = recentlyUsedRanges.filter((recentlyUsedRange) => {
+      const isDuplicate =
+        recentlyUsedRange.start === start && recentlyUsedRange.end === end;
+      return !isDuplicate;
+    });
+    recentlyUsedRange.unshift({ start, end });
+    setStart(start);
+    setEnd(end);
+    setRecentlyUsedRanges(
+      recentlyUsedRange.length > 10
+        ? recentlyUsedRange.slice(0, 9)
+        : recentlyUsedRange
+    );
+    setIsLoading(true);
+    startLoading();
+  };
+
+  const parseTimeRange = (start, end, reportDefinitionRequest) => {
+    timeRange.timeFrom = dateMath.parse(start);
+    timeRange.timeTo = dateMath.parse(end);
+    const timeDuration = moment.duration(
+      dateMath.parse(end).diff(dateMath.parse(start))
+    );
+    reportDefinitionRequest.report_params.core_params.time_duration = timeDuration.toISOString();
+  };
+
+  const onRefresh = ({ start, end, refreshInterval }) => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    }).then(() => {
+      console.log(start, end, refreshInterval);
+    });
+  };
+
+  const startLoading = () => {
+    setTimeout(stopLoading, 1000);
+  };
+
+  const stopLoading = () => {
+    setIsLoading(false);
+  };
+
+  const onRefreshChange = ({ isPaused, refreshInterval }) => {
+    setIsPaused(isPaused);
+    setRefreshInterval(refreshInterval);
+  };
+
+  isValidTimeRange(dateMath.parse(start), 'start');
+  isValidTimeRange(dateMath.parse(end, { roundUp: true }), 'end');
+
+  return (
+    <div>
+      <EuiFormRow
+        label="Time range"
+        helpText="Time range is relative to the report creation date on the report trigger."
+      >
+        <EuiSuperDatePicker
+          isDisabled={false}
+          isLoading={isLoading}
+          start={start}
+          end={end}
+          onTimeChange={onTimeChange}
+          onRefresh={onRefresh}
+          isPaused={isPaused}
+          refreshInterval={refreshInterval}
+          onRefreshChange={onRefreshChange}
+          recentlyUsedRanges={recentlyUsedRanges}
+          showUpdateButton={false}
+        />
+      </EuiFormRow>
+    </div>
+  );
+}

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -132,18 +132,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
     setMonthlyDaySelect(e.target.value);
   };
 
-  const handleMonitor = (e: {
-    target: { value: React.SetStateAction<string> };
-  }) => {
-    setMonitor(e.target.value);
-  };
-
-  const handleTrigger = (e: {
-    target: { value: React.SetStateAction<string> };
-  }) => {
-    setTrigger(e.target.value);
-  };
-
   const TimezoneSelect = () => {
     return (
       <div>
@@ -364,7 +352,9 @@ export function ReportTrigger(props: ReportTriggerProps) {
           label="Custom cron expression"
           labelAppend={
             <EuiText size="xs">
-              <EuiLink href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/cron/">Cron help</EuiLink>
+              <EuiLink href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/cron/">
+                Cron help
+              </EuiLink>
             </EuiText>
           }
         >
@@ -451,60 +441,23 @@ export function ReportTrigger(props: ReportTriggerProps) {
     );
   };
 
-  const AlertTrigger = () => {
-    return (
-      <div>
-        <EuiFlexGroup alignItems="flexStart">
-          <EuiFlexItem>
-            <EuiFormRow label="Select monitor">
-              <EuiSelect
-                id="selectAlertMonitor"
-                options={AVAILABLE_MONITOR_OPTIONS}
-                value={monitor}
-                onChange={handleMonitor}
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiFormRow label="Select trigger">
-              <EuiSelect
-                id="selectAlertTrigger"
-                options={AVAILABLE_TRIGGER_OPTIONS}
-                value={trigger}
-                onChange={handleTrigger}
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-          <EuiFlexItem></EuiFlexItem>
-          <EuiFlexItem></EuiFlexItem>
-          <EuiFlexItem></EuiFlexItem>
-        </EuiFlexGroup>
-      </div>
-    );
-  };
-
   const schedule =
     reportTriggerType === 'Schedule' ? <ScheduleTrigger /> : null;
 
-  const alert = reportTriggerType === 'Alerting' ? <AlertTrigger /> : null;
-
   const defaultEditTriggerType = (trigger_type) => {
     let index = 0;
-    for (index; index < REPORT_TYPE_OPTIONS.length; ++index) {
-      if (REPORT_TYPE_OPTIONS[index].label.includes(trigger_type)) {
-        setReportTriggerType(REPORT_TYPE_OPTIONS[index].id);
+    for (index; index < TRIGGER_TYPE_OPTIONS.length; ++index) {
+      if (TRIGGER_TYPE_OPTIONS[index].label.includes(trigger_type)) {
+        setReportTriggerType(TRIGGER_TYPE_OPTIONS[index].id);
       }
     }
   };
 
   const defaultEditRequestType = (trigger) => {
     let index;
-    for (index in SCHEDULE_REQUEST_TIME_OPTIONS) {
-      if (
-        SCHEDULE_REQUEST_TIME_OPTIONS[index].label ===
-        trigger.trigger_params.schedule_type
-      ) {
-        setScheduleRequestTime(SCHEDULE_REQUEST_TIME_OPTIONS[index].id);
+    for (index in SCHEDULE_TYPE_OPTIONS) {
+      if (SCHEDULE_TYPE_OPTIONS[index].label === trigger.trigger_type) {
+        setScheduleType(SCHEDULE_TYPE_OPTIONS[index].id);
       }
     }
   };
@@ -519,7 +472,7 @@ export function ReportTrigger(props: ReportTriggerProps) {
       httpClientProps
         .get(`../api/reporting/reportDefinitions/${editDefinitionId}`)
         .then(async (response) => {
-          defaultConfigurationEdit(response.trigger);
+          defaultConfigurationEdit(response.report_definition.trigger);
         });
     }
     // Set default trigger_type
@@ -548,7 +501,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
         </EuiFormRow>
         <EuiSpacer />
         {schedule}
-        {alert}
       </EuiPageContentBody>
     </EuiPageContent>
   );

--- a/kibana-reports/server/routes/reportDefinition.ts
+++ b/kibana-reports/server/routes/reportDefinition.ts
@@ -123,17 +123,19 @@ export default function (router: IRouter) {
         return response.badRequest({ body: error });
       }
 
-      let newStatus;
+      let newStatus = REPORT_DEFINITION_STATUS.active;
       /* 
       "enabled = false" means de-scheduling a job.
       TODO: also remove any job in queue and release lock, consider do that
       within the createSchedule API exposed from reports-scheduler
       */
-      const enabled = reportDefinition.trigger.trigger_params.enabled;
-      if (enabled) {
-        newStatus = REPORT_DEFINITION_STATUS.active;
-      } else {
-        newStatus = REPORT_DEFINITION_STATUS.disabled;
+      if (reportDefinition.trigger.trigger_type == 'Schedule') {
+        const enabled = reportDefinition.trigger.trigger_params.enabled;
+        if (enabled) {
+          newStatus = REPORT_DEFINITION_STATUS.active;
+        } else {
+          newStatus = REPORT_DEFINITION_STATUS.disabled;
+        }
       }
 
       // Update report definition metadata


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Fixed the `Edit Report Definition` page to pre-populate fields correctly based on the new schema
* `Report Settings` fields pre-populate properly, including time range (always relative) 
* Report trigger pre-populates the trigger type correctly
   * For schedules, the schema does not support the granularity of the schedule (e.g Daily recurring vs. By interval recurring)
* Added breadcrumbs nav bar for `Edit` page
* Extracted `TimeRangeSelect` in `Report Settings` and helper functions into separate files to reduce clutter 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
