### PR TITLE
Update the ES query result size from default 100 to default max value 10000

### DIFF
--- a/kibana-reports/server/model/index.ts
+++ b/kibana-reports/server/model/index.ts
@@ -23,6 +23,7 @@ import {
   REPORT_DEFINITION_STATUS,
   DELIVERY_TYPE,
   EMAIL_FORMAT,
+  DEFAULT_MAX_SIZE,
 } from '../routes/utils/constants';
 
 export const dataReportSchema = schema.object({
@@ -32,7 +33,7 @@ export const dataReportSchema = schema.object({
   time_duration: schema.string(),
   //TODO: future support schema.literal('xlsx')
   report_format: schema.oneOf([schema.literal(FORMAT.csv)]),
-  limit: schema.number({ defaultValue: 10000 }),
+  limit: schema.number({ defaultValue: DEFAULT_MAX_SIZE }),
   excel: schema.boolean({ defaultValue: true }),
 });
 

--- a/kibana-reports/server/routes/reportDefinition.ts
+++ b/kibana-reports/server/routes/reportDefinition.ts
@@ -30,6 +30,7 @@ import {
   REPORT_DEFINITION_STATUS,
   TRIGGER_TYPE,
   CONFIG_INDEX_NAME,
+  DEFAULT_MAX_SIZE,
 } from './utils/constants';
 
 export default function (router: IRouter) {
@@ -190,7 +191,7 @@ export default function (router: IRouter) {
       path: `${API_PREFIX}/reportDefinitions`,
       validate: {
         query: schema.object({
-          size: schema.string({ defaultValue: '100' }),
+          size: schema.maybe(schema.string()),
           sortField: schema.maybe(schema.string()),
           sortDirection: schema.maybe(schema.string()),
         }),
@@ -206,11 +207,13 @@ export default function (router: IRouter) {
         sortField: string;
         sortDirection: string;
       };
-      const sizeNumber = parseInt(size, 10);
       const params: RequestParams.Search = {
         index: CONFIG_INDEX_NAME.reportDefinition,
-        size: sizeNumber,
-        sort: `${sortField}:${sortDirection}`,
+        size: size ? parseInt(size, 10) : DEFAULT_MAX_SIZE,
+        sort:
+          sortField && sortDirection
+            ? `${sortField}:${sortDirection}`
+            : undefined,
       };
       try {
         const esResp = await context.core.elasticsearch.legacy.client.callAsCurrentUser(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the ES query result size from default 100 to default max value 10000

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
