### PR TITLE
Input Validation for Create Report Definition

### DIFF
--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -29,6 +29,7 @@
     "@nteract/markdown": "^4.5.1",
     "@types/showdown": "^1.9.3",
     "babel-polyfill": "^6.26.0",
+    "cron-validator": "^1.1.1",
     "elastic-builder": "^2.7.1",
     "jquery": "^3.5.0",
     "json-2-csv": "^3.7.6",

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -205,11 +205,22 @@ export function CreateReport(props) {
         error = true;
       }
     }
-    // if email delivery and no recipients are listed
+    // if email delivery 
     if (metadata.delivery.delivery_type === 'Channel') {
+      // no recipients are listed
       if (metadata.delivery.delivery_params.recipients.length === 0) {
         setShowEmailRecipientsError(true);
         error = true;
+      }
+      // recipients have invalid email addresses: regexp checks format xxxxx@yyyy.zzz
+      let emailRegExp = /\S+@\S+\.\S+/;
+      let index;
+      let recipients = metadata.delivery.delivery_params.recipients;
+      for (index = 0; index < recipients.length; ++index) {
+        if (recipients[0].search(emailRegExp) === -1) {
+          setShowEmailRecipientsError(true);
+          error = true;
+        }
       }
     }
     return error;

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -132,7 +132,6 @@ export function CreateReport(props) {
   // preserve the state of the request after an invalid create report definition request
   if (comingFromError) {
     createReportDefinitionRequest = preErrorData;
-    console.log(createReportDefinitionRequest);
   }
 
   const addErrorToastHandler = () => {
@@ -238,7 +237,6 @@ export function CreateReport(props) {
       handleErrorToast();
       setPreErrorData(metadata);
       setComingFromError(true);
-      console.log('pre error data is', metadata);
     } else {
       httpClient
         .post('../api/reporting/reportDefinition', {

--- a/kibana-reports/public/components/report_definitions/delivery/delivery.tsx
+++ b/kibana-reports/public/components/report_definitions/delivery/delivery.tsx
@@ -24,10 +24,8 @@ import {
   EuiSpacer,
   EuiRadioGroup,
 } from '@elastic/eui';
-import { KibanaUserDelivery } from './kibana_user'
-import {
-  DELIVERY_TYPE_OPTIONS
-} from './delivery_constants';
+import { KibanaUserDelivery } from './kibana_user';
+import { DELIVERY_TYPE_OPTIONS } from './delivery_constants';
 import 'react-mde/lib/styles/css/react-mde-all.css';
 import { reportDefinitionParams } from '../create/create_report_definition';
 import { EmailDelivery } from './email';
@@ -37,6 +35,7 @@ export type ReportDeliveryProps = {
   editDefinitionId: string;
   reportDefinitionRequest: reportDefinitionParams;
   httpClientProps: any;
+  showEmailRecipientsError: boolean;
 };
 
 export function ReportDelivery(props: ReportDeliveryProps) {
@@ -45,8 +44,9 @@ export function ReportDelivery(props: ReportDeliveryProps) {
     editDefinitionId,
     reportDefinitionRequest,
     httpClientProps,
+    showEmailRecipientsError,
   } = props;
-  
+
   const [deliveryType, setDeliveryType] = useState(DELIVERY_TYPE_OPTIONS[0].id);
 
   const handleDeliveryType = (e: string) => {
@@ -55,10 +55,12 @@ export function ReportDelivery(props: ReportDeliveryProps) {
   };
 
   const deliverySetting = (props: ReportDeliveryProps) => {
-    return (
-      deliveryType === DELIVERY_TYPE_OPTIONS[0].id ? <KibanaUserDelivery {...props} /> : <EmailDelivery {...props} />
-    )
-  }
+    return deliveryType === DELIVERY_TYPE_OPTIONS[0].id ? (
+      <KibanaUserDelivery {...props} />
+    ) : (
+      <EmailDelivery {...props} />
+    );
+  };
 
   useEffect(() => {
     if (edit) {
@@ -81,13 +83,13 @@ export function ReportDelivery(props: ReportDeliveryProps) {
       </EuiPageHeader>
       <EuiHorizontalRule />
       <EuiPageContentBody>
-      <EuiFormRow label="Delivery type">
+        <EuiFormRow label="Delivery type">
           <EuiRadioGroup
             options={DELIVERY_TYPE_OPTIONS}
             idSelected={deliveryType}
             onChange={handleDeliveryType}
           />
-      </EuiFormRow>
+        </EuiFormRow>
         <EuiSpacer />
         {deliverySetting(props)}
       </EuiPageContentBody>

--- a/kibana-reports/public/components/report_definitions/delivery/email.tsx
+++ b/kibana-reports/public/components/report_definitions/delivery/email.tsx
@@ -76,6 +76,7 @@ export const EmailDelivery = (props: ReportDeliveryProps) => {
     editDefinitionId,
     reportDefinitionRequest,
     httpClientProps,
+    showEmailRecipientsError,
   } = props;
 
   const [emailRecipients, setEmailRecipients] = useState([]);
@@ -212,7 +213,11 @@ export const EmailDelivery = (props: ReportDeliveryProps) => {
 
   return (
     <div>
-      <EuiFormRow label="Email recipients" helpText="Select or add users">
+      <EuiFormRow
+        label="Email recipients"
+        helpText="Select or add users"
+        isInvalid={showEmailRecipientsError}
+      >
         <EuiComboBox
           placeholder={'Add users here'}
           options={EMAIL_RECIPIENT_OPTIONS}

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -61,6 +61,7 @@ type ReportSettingProps = {
   reportDefinitionRequest: reportDefinitionParams;
   httpClientProps: any;
   timeRange: timeRangeParams;
+  showSettingsReportNameError: boolean;
 };
 
 export function ReportSettings(props: ReportSettingProps) {
@@ -70,6 +71,7 @@ export function ReportSettings(props: ReportSettingProps) {
     reportDefinitionRequest,
     httpClientProps,
     timeRange,
+    showSettingsReportNameError,
   } = props;
 
   const [reportName, setReportName] = useState('');
@@ -532,6 +534,7 @@ export function ReportSettings(props: ReportSettingProps) {
             <EuiFormRow
               label="Name"
               helpText="Valid characters are a-z, A-Z, 0-9, (), [], _ (underscore), - (hyphen) and (space)."
+              isInvalid={showSettingsReportNameError}
             >
               <EuiFieldText
                 placeholder="Report name (e.g Log Traffic Daily Report)"

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -56,6 +56,8 @@ type ReportTriggerProps = {
   editDefinitionId: string;
   reportDefinitionRequest: reportDefinitionParams;
   httpClientProps: any;
+  showTriggerIntervalNaNError: boolean;
+  showCronError: boolean;
 };
 
 export function ReportTrigger(props: ReportTriggerProps) {
@@ -64,6 +66,8 @@ export function ReportTrigger(props: ReportTriggerProps) {
     editDefinitionId,
     reportDefinitionRequest,
     httpClientProps,
+    showTriggerIntervalNaNError,
+    showCronError,
   } = props;
 
   const [reportTriggerType, setReportTriggerType] = useState(
@@ -111,6 +115,13 @@ export function ReportTrigger(props: ReportTriggerProps) {
 
   const handleTimezone = (e) => {
     setTimezone(e.target.value);
+    if (
+      reportDefinitionRequest.trigger.trigger_params.schedule_type ===
+      'Cron based'
+    ) {
+      reportDefinitionRequest.trigger.trigger_params.schedule.cron.timezone =
+        e.target.value;
+    }
   };
 
   const handleScheduleRecurringFrequency = (e: {
@@ -231,7 +242,7 @@ export function ReportTrigger(props: ReportTriggerProps) {
 
     return (
       <div>
-        <EuiFormRow label="Every">
+        <EuiFormRow label="Every" isInvalid={showTriggerIntervalNaNError}>
           <EuiFlexGroup>
             <EuiFlexItem grow={false}>
               <EuiFieldText
@@ -345,8 +356,6 @@ export function ReportTrigger(props: ReportTriggerProps) {
       target: { value: React.SetStateAction<string> };
     }) => {
       setCronExpression(e.target.value);
-      reportDefinitionRequest.trigger.trigger_params.schedule.cron.expression =
-        e.target.value;
     };
 
     useEffect(() => {
@@ -385,6 +394,7 @@ export function ReportTrigger(props: ReportTriggerProps) {
       <div>
         <EuiFormRow
           label="Custom cron expression"
+          isInvalid={showCronError}
           labelAppend={
             <EuiText size="xs">
               <EuiLink href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/cron/">

--- a/kibana-reports/yarn.lock
+++ b/kibana-reports/yarn.lock
@@ -3212,6 +3212,11 @@ create-react-context@^0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
+cron-validator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.1.1.tgz#0a27bb75508c7bc03c8b840d2d9f170eeacb5615"
+  integrity sha512-vfZb05w/wezuwPZBDvdIBmJp2BvuJExHeyKRa5oBqD2ZDXR61hb3QgPc/3ZhBEQJlAy8Jlnn5XC/JCT3IDqxwg==
+
 cross-env@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"


### PR DESCRIPTION
*Issue #, if available:*
#90 
*Description of changes:*
Added input validation on required fields from the client side on `Create report definition`
* Added requirements for `Report name` abiding by the allowed characters listed in the field 
* Added requirements for the interval to populated with a number when `Recurring By interval` is selected
* Added cron validation for `Cron-based` schedule definitions
* Added requirements that the list of email recipients cannot be empty when delivering reports by email

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
