### PR TITLE
Context Menu Fixes 

### DIFF
--- a/kibana-reports/public/components/context_menu/context_menu_helpers.js
+++ b/kibana-reports/public/components/context_menu/context_menu_helpers.js
@@ -108,9 +108,11 @@ export const addSuccessOrFailureToast = (status) => {
       const generateInProgressToast = document.createElement("div");
       if (status === "success") {
         generateInProgressToast.innerHTML = reportGenerationSuccess();
+        setTimeout(function () {document.getElementById('reportSuccessToast').style.display='none'}, 6000); // closes toast automatically after 6s
       }
       else if (status === "failure") {
-        generateInProgressToast.innerHTML = reportGenerationFailure()
+        generateInProgressToast.innerHTML = reportGenerationFailure();
+        setTimeout(function () {document.getElementById('reportFailureToast').style.display='none'}, 6000);
       }
       generateToast[0].appendChild(generateInProgressToast.children[0]);
     } catch (e) {

--- a/kibana-reports/public/components/context_menu/context_menu_ui.js
+++ b/kibana-reports/public/components/context_menu/context_menu_ui.js
@@ -121,7 +121,7 @@ export const reportGenerationSuccess = () => {
     <div class="euiText euiText--small euiToastBody">
       <p>Your report is available in 
         <a class="euiLink euiLink--primary"
-        href="opendistro_kibana_report#/" rel="noreferrer">Reports</a>.</p>
+        href="opendistro_kibana_reports#/" rel="noreferrer">Reports</a>.</p>
     </div>
   </div>
   `

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -144,7 +144,7 @@ export function ReportSettings(props: ReportSettingProps) {
   }) => {
     setDashboardSourceSelect(e.target.value);
     reportDefinitionRequest.report_params.core_params.base_url =
-      getDashboardBaseUrlCreate() + e.target.value;
+      getDashboardBaseUrlCreate(edit, editDefinitionId) + e.target.value;
   };
 
   const handleVisualizationSelect = (e: {
@@ -152,7 +152,7 @@ export function ReportSettings(props: ReportSettingProps) {
   }) => {
     setVisualizationSourceSelect(e.target.value);
     reportDefinitionRequest.report_params.core_params.base_url =
-      getVisualizationBaseUrlCreate() + e.target.value;
+      getVisualizationBaseUrlCreate(edit) + e.target.value;
   };
 
   const handleSavedSearchSelect = (e: {
@@ -398,6 +398,18 @@ export function ReportSettings(props: ReportSettingProps) {
     }
   };
 
+  const setInContextDefaultConfiguration = () => {
+    const url = window.location.href;
+    const id = parseInContextUrl(url, 'id');
+    if (url.includes('dashboard')) {
+      setReportSourceId('dashboardReportSource');
+      setDashboardSourceSelect(id);
+    } else if (url.includes('visualize')) {
+      setReportSourceId('visualizationReportSource');
+      setVisualizationSourceSelect(id);
+    }
+  };
+
   const setDefaultEditValues = async (response, reportSourceOptions) => {
     setReportName(response.report_definition.report_params.report_name);
     setReportDescription(response.report_definition.report_params.description);
@@ -454,7 +466,7 @@ export function ReportSettings(props: ReportSettingProps) {
           setDashboardSourceSelect(dashboardOptions[0].value);
           reportDefinitionRequest.report_params.report_source = 'Dashboard';
           reportDefinitionRequest['report_params']['core_params']['base_url'] =
-            getDashboardBaseUrlCreate() +
+            getDashboardBaseUrlCreate(edit, editDefinitionId) +
             response['hits']['hits'][0]['_id'].substring(10);
         }
       })
@@ -502,22 +514,14 @@ export function ReportSettings(props: ReportSettingProps) {
     }
     defaultConfigurationCreate(httpClientProps).then(async (response) => {
       reportSourceOptions = response;
+      // if coming from in-context menu
+      if (window.location.href.indexOf('?') > -1) {
+        setInContextDefaultConfiguration();
+      }
       if (edit) {
         setDefaultEditValues(editData, reportSourceOptions);
       }
     });
-
-    if (window.location.href.indexOf('?') > -1) {
-      const url = window.location.href;
-      const id = parseInContextUrl(url, 'id');
-      if (url.includes('dashboard')) {
-        setReportSourceId('dashboardReportSource');
-        setDashboardSourceSelect(id);
-      } else if (url.includes('visualize')) {
-        setReportSourceId('visualizationReportSource');
-        setVisualizationSourceSelect(id);
-      }
-    }
   }, []);
 
   return (


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Fixed some bugs in the context menu.
* The link in the `Success` toast to the `Reports` homepage works now
* Pre-selection of a report source after navigating to `Create report definition` from the context menu works
* Toasts now disappear after `6 seconds` instead of requiring the user closing manually. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
