### PR TITLE
Time Range Fixes

### DIFF
--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -29,6 +29,7 @@ import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
 import { generateReport } from '../../main/main_utils';
 import { isValidCron } from 'cron-validator';
+import moment from 'moment';
 
 interface reportParamsType {
   report_name: string;
@@ -128,6 +129,7 @@ export function CreateReport(props) {
   const [showEmailRecipientsError, setShowEmailRecipientsError] = useState(
     false
   );
+  const [showTimeRangeError, setShowTimeRangeError] = useState(false);
 
   // preserve the state of the request after an invalid create report definition request
   if (comingFromError) {
@@ -162,6 +164,20 @@ export function CreateReport(props) {
     addSuccessToastHandler();
   };
 
+  const addInvalidTimeRangeToastHandler = () => {
+    const errorToast = {
+      title: 'Invalid time range selected',
+      color: 'danger',
+      iconType: 'alert',
+      id: 'timeRangeErrorToast',
+    };
+    setToasts(toasts.concat(errorToast));
+  };
+
+  const handleInvalidTimeRangeToast = () => {
+    addInvalidTimeRangeToastHandler();
+  };
+
   const removeToast = (removedToast) => {
     setToasts(toasts.filter((toast) => toast.id !== removedToast.id));
   };
@@ -179,6 +195,7 @@ export function CreateReport(props) {
       setShowSettingsReportNameError(true);
       error = true;
     }
+
     // if recurring by interval and input is not a number
     if (
       metadata.trigger.trigger_type === 'Schedule' &&
@@ -193,6 +210,13 @@ export function CreateReport(props) {
       }
     }
 
+    // if time range is invalid
+    const nowDate = new Date(moment.now());
+    if (timeRange.timeFrom > timeRange.timeTo || timeRange.timeTo > nowDate) {
+      setShowTimeRangeError(true);
+      error = true;
+    }
+
     // if cron based and cron input is invalid
     if (
       metadata.trigger.trigger_type === 'Schedule' &&
@@ -205,7 +229,7 @@ export function CreateReport(props) {
         error = true;
       }
     }
-    // if email delivery 
+    // if email delivery
     if (metadata.delivery.delivery_type === 'Channel') {
       // no recipients are listed
       if (metadata.delivery.delivery_params.recipients.length === 0) {
@@ -305,6 +329,7 @@ export function CreateReport(props) {
           httpClientProps={props['httpClient']}
           timeRange={timeRange}
           showSettingsReportNameError={showSettingsReportNameError}
+          showTimeRangeError={showTimeRangeError}
         />
         <EuiSpacer />
         <ReportTrigger

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -62,6 +62,7 @@ type ReportSettingProps = {
   httpClientProps: any;
   timeRange: timeRangeParams;
   showSettingsReportNameError: boolean;
+  showTimeRangeError: boolean;
 };
 
 export function ReportSettings(props: ReportSettingProps) {
@@ -72,6 +73,7 @@ export function ReportSettings(props: ReportSettingProps) {
     httpClientProps,
     timeRange,
     showSettingsReportNameError,
+    showTimeRangeError,
   } = props;
 
   const [reportName, setReportName] = useState('');
@@ -278,17 +280,6 @@ export function ReportSettings(props: ReportSettingProps) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        <TimeRangeSelect
-          reportDefinitionRequest={reportDefinitionRequest}
-          timeRange={timeRange}
-          edit={edit}
-          id={editDefinitionId}
-          httpClientProps={httpClientProps}
-        />
-        <EuiSpacer />
-        <PDFandPNGFileFormats />
-        <EuiSpacer />
-        <SettingsMarkdown />
       </div>
     );
   };
@@ -305,17 +296,6 @@ export function ReportSettings(props: ReportSettingProps) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        <TimeRangeSelect
-          timeRange={timeRange}
-          reportDefinitionRequest={reportDefinitionRequest}
-          edit={edit}
-          id={editDefinitionId}
-          httpClientProps={httpClientProps}
-        />
-        <EuiSpacer />
-        <PDFandPNGFileFormats />
-        <EuiSpacer />
-        <SettingsMarkdown />
       </div>
     );
   };
@@ -332,37 +312,19 @@ export function ReportSettings(props: ReportSettingProps) {
           />
         </EuiFormRow>
         <EuiSpacer />
-        <TimeRangeSelect
-          timeRange={timeRange}
-          reportDefinitionRequest={reportDefinitionRequest}
-          edit={edit}
-          id={editDefinitionId}
-          httpClientProps={httpClientProps}
-        />
-        <EuiSpacer />
-        <EuiFormRow label="File format">
-          <EuiText>
-            <p>CSV</p>
-          </EuiText>
-        </EuiFormRow>
       </div>
     );
   };
 
-  const displayDashboardSelect =
-    reportSourceId === 'dashboardReportSource' ? (
-      <ReportSourceDashboard />
-    ) : null;
-
-  const displayVisualizationSelect =
-    reportSourceId === 'visualizationReportSource' ? (
-      <ReportSourceVisualization />
-    ) : null;
-
-  const displaySavedSearchSelect =
-    reportSourceId === 'savedSearchReportSource' ? (
-      <ReportSourceSavedSearch />
-    ) : null;
+  const VisualReportFormatAndMarkdown = () => {
+    return (
+      <div>
+        <PDFandPNGFileFormats />
+        <EuiSpacer />
+        <SettingsMarkdown />
+      </div>
+    );
+  };
 
   const setReportSourceDropdownOption = (options, reportSource, url) => {
     let index = 0;
@@ -524,6 +486,34 @@ export function ReportSettings(props: ReportSettingProps) {
     });
   }, []);
 
+  const displayDashboardSelect =
+    reportSourceId === 'dashboardReportSource' ? (
+      <ReportSourceDashboard />
+    ) : null;
+
+  const displayVisualizationSelect =
+    reportSourceId === 'visualizationReportSource' ? (
+      <ReportSourceVisualization />
+    ) : null;
+
+  const displaySavedSearchSelect =
+    reportSourceId === 'savedSearchReportSource' ? (
+      <ReportSourceSavedSearch />
+    ) : null;
+
+  const displayVisualReportsFormatAndMarkdown =
+    reportSourceId != 'savedSearchReportSource' ? (
+      <VisualReportFormatAndMarkdown />
+    ) : (
+      <div>
+        <EuiFormRow label="File format">
+          <EuiText>
+            <p>CSV</p>
+          </EuiText>
+        </EuiFormRow>
+      </div>
+    );
+
   return (
     <EuiPageContent panelPaddingSize={'l'}>
       <EuiPageHeader>
@@ -571,6 +561,16 @@ export function ReportSettings(props: ReportSettingProps) {
         {displayDashboardSelect}
         {displayVisualizationSelect}
         {displaySavedSearchSelect}
+        <TimeRangeSelect
+          timeRange={timeRange}
+          reportDefinitionRequest={reportDefinitionRequest}
+          edit={edit}
+          id={editDefinitionId}
+          httpClientProps={httpClientProps}
+          showTimeRangeError={showTimeRangeError}
+        />
+        <EuiSpacer />
+        {displayVisualReportsFormatAndMarkdown}
         <EuiSpacer />
       </EuiPageContentBody>
     </EuiPageContent>


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Selecting an invalid time range shows a toast notification error instead of throwing error and crashing the page
* Submitting a new report definition with an invalid time range will show an error toast and highlight the `Time range` field red
* `Time Range` no longer resets to the default `Last 30 minutes` value when another field in `Report settings` is chosen 
* Time range durations are saved correctly in the schema 
* Time range durations are saved successfully on `Edit`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
