### PR TITLE
Header & Footer Plaintext Support 

### DIFF
--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -250,7 +250,6 @@ export function ReportDefinitionDetails(props) {
     httpClient
       .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
       .then((response) => {
-        console.log('response is', response);
         handleReportDefinitionRawResponse(response);
         handleReportDefinitionDetails(
           getReportDefinitionDetailsMetadata(response)

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -214,8 +214,14 @@ export function ReportDefinitionDetails(props) {
       timePeriod: moment.duration(timeDuration).humanize(),
       fileFormat: reportFormat,
       // TODO: to be added to schema, currently hardcoded in backend
-      reportHeader: `\u2014`,
-      reportFooter: `\u2014`,
+      reportHeader:
+        reportParams.core_params.header != ''
+          ? reportParams.core_params.header
+          : `\u2014`,
+      reportFooter:
+        reportParams.core_params.footer != ''
+          ? reportParams.core_params.footer
+          : `\u2014`,
       triggerType: triggerType,
       scheduleDetails: triggerParams ? triggerParams.schedule_type : `\u2014`,
       alertDetails: `\u2014`,
@@ -244,6 +250,7 @@ export function ReportDefinitionDetails(props) {
     httpClient
       .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
       .then((response) => {
+        console.log('response is', response);
         handleReportDefinitionRawResponse(response);
         handleReportDefinitionDetails(
           getReportDefinitionDetailsMetadata(response)

--- a/kibana-reports/public/components/main/report_details/report_details.tsx
+++ b/kibana-reports/public/components/main/report_details/report_details.tsx
@@ -157,7 +157,6 @@ export function ReportDetails(props) {
     httpClient
       .get('../api/reporting/reports/' + reportId)
       .then((response) => {
-        console.log('response is', response);
         handleReportDetails(getReportDetailsData(response));
         props.setBreadcrumbs([
           {

--- a/kibana-reports/public/components/main/report_details/report_details.tsx
+++ b/kibana-reports/public/components/main/report_details/report_details.tsx
@@ -120,8 +120,14 @@ export function ReportDetails(props) {
       time_period: lastUpdated,
       defaultFileFormat: coreParams.report_format,
       state: state,
-      reportHeader: `\u2014`,
-      reportFooter: `\u2014`,
+      reportHeader:
+        reportParams.core_params.header != ''
+          ? reportParams.core_params.header
+          : `\u2014`,
+      reportFooter:
+        reportParams.core_params.footer != ''
+          ? reportParams.core_params.footer
+          : `\u2014`,
       triggerType: triggerType,
       scheduleType: triggerParams ? triggerParams.schedule_type : `\u2014`,
       scheduleDetails: `\u2014`,
@@ -151,6 +157,7 @@ export function ReportDetails(props) {
     httpClient
       .get('../api/reporting/reports/' + reportId)
       .then((response) => {
+        console.log('response is', response);
         handleReportDetails(getReportDetailsData(response));
         props.setBreadcrumbs([
           {

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -35,6 +35,8 @@ interface reportParamsType {
   report_name: string;
   report_source: string;
   description: string;
+  header: string;
+  footer: string;
   core_params: visualReportParams | dataReportParams;
 }
 interface visualReportParams {
@@ -98,6 +100,8 @@ export function CreateReport(props) {
       report_name: '',
       report_source: '',
       description: '',
+      header: '',
+      footer: '',
       core_params: {
         base_url: '',
         report_format: '',

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -35,13 +35,13 @@ interface reportParamsType {
   report_name: string;
   report_source: string;
   description: string;
-  header: string;
-  footer: string;
   core_params: visualReportParams | dataReportParams;
 }
 interface visualReportParams {
   base_url: string;
   report_format: string;
+  header: string;
+  footer: string;
   time_duration: string;
 }
 
@@ -100,11 +100,11 @@ export function CreateReport(props) {
       report_name: '',
       report_source: '',
       description: '',
-      header: '',
-      footer: '',
       core_params: {
         base_url: '',
         report_format: '',
+        header: '',
+        footer: '',
         time_duration: '',
       },
     },

--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -59,6 +59,8 @@ export function EditReportDefinition(props) {
       core_params: {
         base_url: '',
         report_format: '',
+        header: '',
+        footer: '',
         time_duration: '',
       },
     },

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -380,7 +380,6 @@ export function ReportSettings(props: ReportSettingProps) {
       <div>
         <PDFandPNGFileFormats />
         <EuiSpacer />
-        {/* <SettingsMarkdown /> */}
       </div>
     );
   };

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -209,12 +209,12 @@ export function ReportSettings(props: ReportSettingProps) {
 
     const handleHeader = (e) => {
       setHeader(e);
-      reportDefinitionRequest.report_params.header = e;
+      reportDefinitionRequest.report_params.core_params.header = e;
     };
 
     const handleFooter = (e) => {
       setFooter(e);
-      reportDefinitionRequest.report_params.footer = e;
+      reportDefinitionRequest.report_params.core_params.footer = e;
     };
 
     const handleCheckboxHeaderFooter = (optionId) => {
@@ -262,6 +262,55 @@ export function ReportSettings(props: ReportSettingProps) {
         />
       </EuiFormRow>
     ) : null;
+
+    useEffect(() => {
+      let unmounted = false;
+      if (edit) {
+        httpClientProps
+          .get(`../api/reporting/reportDefinitions/${editDefinitionId}`)
+          .then(async (response: {}) => {
+            // set header/footer default
+            if (
+              response.report_definition.report_params.core_params.header != ''
+            ) {
+              checkboxIdSelectHeaderFooter.header = true;
+              if (!unmounted) {
+                setHeader(
+                  response.report_definition.report_params.core_params.header
+                );
+              }
+            }
+            if (
+              response.report_definition.report_params.core_params.footer != ''
+            ) {
+              checkboxIdSelectHeaderFooter.footer = true;
+              if (!unmounted) {
+                setFooter(
+                  response.report_definition.report_params.core_params.footer
+                );
+              }
+            }
+          })
+          .catch((error: any) => {
+            console.error(
+              'error in fetching report definition details:',
+              error
+            );
+          });
+      } else {
+        if (reportDefinitionRequest.report_params.core_params.header != '') {
+          checkboxIdSelectHeaderFooter.header = true;
+          setHeader(reportDefinitionRequest.report_params.core_params.header);
+        }
+        if (reportDefinitionRequest.report_params.core_params.footer != '') {
+          checkboxIdSelectHeaderFooter.footer = true;
+          setFooter(reportDefinitionRequest.report_params.core_params.footer);
+        }
+      }
+      return () => {
+        unmounted = true;
+      };
+    }, []);
 
     return (
       <div>
@@ -331,7 +380,7 @@ export function ReportSettings(props: ReportSettingProps) {
       <div>
         <PDFandPNGFileFormats />
         <EuiSpacer />
-        <SettingsMarkdown />
+        {/* <SettingsMarkdown /> */}
       </div>
     );
   };
@@ -513,7 +562,10 @@ export function ReportSettings(props: ReportSettingProps) {
 
   const displayVisualReportsFormatAndMarkdown =
     reportSourceId != 'savedSearchReportSource' ? (
-      <VisualReportFormatAndMarkdown />
+      <div>
+        <VisualReportFormatAndMarkdown />
+        <SettingsMarkdown />
+      </div>
     ) : (
       <div>
         <EuiFormRow label="File format">

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -207,6 +207,16 @@ export function ReportSettings(props: ReportSettingProps) {
       'write' | 'preview'
     >('write');
 
+    const handleHeader = (e) => {
+      setHeader(e);
+      reportDefinitionRequest.report_params.header = e;
+    };
+
+    const handleFooter = (e) => {
+      setFooter(e);
+      reportDefinitionRequest.report_params.footer = e;
+    };
+
     const handleCheckboxHeaderFooter = (optionId) => {
       const newCheckboxIdToSelectedMap = {
         ...checkboxIdSelectHeaderFooter,
@@ -221,7 +231,7 @@ export function ReportSettings(props: ReportSettingProps) {
       <EuiFormRow label="Footer" fullWidth={true}>
         <ReactMde
           value={footer}
-          onChange={setFooter}
+          onChange={handleFooter}
           selectedTab={selectedTabFooter}
           onTabChange={setSelectedTabFooter}
           toolbarCommands={[
@@ -239,7 +249,7 @@ export function ReportSettings(props: ReportSettingProps) {
       <EuiFormRow label="Header" fullWidth={true}>
         <ReactMde
           value={header}
-          onChange={setHeader}
+          onChange={handleHeader}
           selectedTab={selectedTabHeader}
           onTabChange={setSelectedTabHeader}
           toolbarCommands={[

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -526,9 +526,12 @@ export function ReportTrigger(props: ReportTriggerProps) {
 
   const defaultConfigurationEdit = (trigger) => {
     defaultEditTriggerType(trigger.trigger_type);
-    defaultEditRequestType(trigger);
     if (trigger.trigger_type === 'Schedule') {
       defaultEditScheduleFrequency(trigger.trigger_params);
+      defaultEditRequestType(trigger);
+    } else if (trigger.trigger_type == 'On demand') {
+      setReportTriggerType('On demand');
+      reportDefinitionRequest.trigger.trigger_type = 'On demand';
     }
   };
 

--- a/kibana-reports/server/model/index.ts
+++ b/kibana-reports/server/model/index.ts
@@ -113,7 +113,8 @@ export const reportDefinitionSchema = schema.object({
       schema.literal(REPORT_TYPE.savedSearch),
     ]),
     description: schema.string(),
-
+    header: schema.string(),
+    footer: schema.string(),
     core_params: schema.conditional(
       schema.siblingRef('report_source'),
       REPORT_TYPE.savedSearch,

--- a/kibana-reports/server/model/index.ts
+++ b/kibana-reports/server/model/index.ts
@@ -45,6 +45,8 @@ const visualReportSchema = schema.object({
     schema.literal(FORMAT.pdf),
     schema.literal(FORMAT.png),
   ]),
+  header: schema.string(),
+  footer: schema.string(),
   time_duration: schema.string(),
 });
 
@@ -113,8 +115,6 @@ export const reportDefinitionSchema = schema.object({
       schema.literal(REPORT_TYPE.savedSearch),
     ]),
     description: schema.string(),
-    header: schema.string(),
-    footer: schema.string(),
     core_params: schema.conditional(
       schema.siblingRef('report_source'),
       REPORT_TYPE.savedSearch,

--- a/kibana-reports/server/routes/utils/reportHelper.ts
+++ b/kibana-reports/server/routes/utils/reportHelper.ts
@@ -46,8 +46,8 @@ export const createVisualReport = async (
   const reportFormat = coreParams.report_format;
 
   // TODO: replace placeholders with actual schema data fields
-  const header = 'Test report header sample text';
-  const footer = 'Test report footer sample text';
+  const header = reportParams.header;
+  const footer = reportParams.footer;
   // set up puppeteer
   const browser = await puppeteer.launch({
     headless: true,


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Header and footer have plain-text support and will display in the report header and footer as plaintext.

`TODO`: Add formatting to the report to clean up the display of the header and footer with the report. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
