### PR TITLE
Add download to reportDetails and reportDefinitionDetails

### DIFF
--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -274,7 +274,7 @@ export function ReportDefinitionDetails(props) {
     let formatUpper = data['fileFormat'];
     formatUpper = fileFormatsUpper[formatUpper];
     return (
-      <EuiLink>
+      <EuiLink onClick={generateReportFromDetails}>
         {formatUpper + ' '}
         <EuiIcon type="importAction" />
       </EuiLink>

--- a/kibana-reports/public/components/main/report_details/report_details.tsx
+++ b/kibana-reports/public/components/main/report_details/report_details.tsx
@@ -33,7 +33,7 @@ import {
   EuiIcon,
   EuiGlobalToastList,
 } from '@elastic/eui';
-import { fileFormatsUpper } from '../main_utils';
+import { fileFormatsUpper, generateReportById } from '../main_utils';
 import { ReportSchemaType } from '../../../../server/model';
 
 export const ReportDetailsComponent = (props) => {
@@ -71,6 +71,20 @@ export function ReportDetails(props) {
 
   const handleErrorToast = () => {
     addErrorToastHandler();
+  };
+
+  const addSuccessToastHandler = () => {
+    const successToast = {
+      title: 'Success',
+      color: 'success',
+      text: <p>Report successfully downloaded!</p>,
+      id: 'onDemandDownloadSuccessToast',
+    };
+    setToasts(toasts.concat(successToast));
+  };
+
+  const handleSuccessToast = () => {
+    addSuccessToastHandler();
   };
 
   const removeToast = (removedToast) => {
@@ -180,7 +194,9 @@ export function ReportDetails(props) {
     let formatUpper = data['defaultFileFormat'];
     formatUpper = fileFormatsUpper[formatUpper];
     return (
-      <EuiLink>
+      <EuiLink onClick={() => {
+        generateReportById(reportId, props.httpClient, handleSuccessToast, handleErrorToast);
+      }}>
         {formatUpper + ' '}
         <EuiIcon type="importAction" />
       </EuiLink>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add download functionality when user clicks download button in file format column in Report details & Report definition details
![image](https://user-images.githubusercontent.com/28062824/96788227-fe30a880-13a7-11eb-8fc8-3ef95d635ced.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
