### PR TITLE
Report Definition Details Display Change

### DIFF
--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -35,6 +35,8 @@ import { fileFormatsUpper, generateReport } from '../main_utils';
 import { ReportDefinitionSchemaType } from '../../../../server/model';
 import moment from 'moment';
 
+const ON_DEMAND = 'On demand';
+
 export function ReportDefinitionDetails(props) {
   const [reportDefinitionDetails, setReportDefinitionDetails] = useState({});
   const [
@@ -419,7 +421,7 @@ export function ReportDefinitionDetails(props) {
   };
 
   const showActionButton =
-    reportDefinitionDetails.triggerType === 'On demand' ? (
+    reportDefinitionDetails.triggerType === ON_DEMAND ? (
       <EuiButton onClick={() => generateReportFromDetails()}>
         Generate report
       </EuiButton>
@@ -428,7 +430,7 @@ export function ReportDefinitionDetails(props) {
     );
 
   const triggerSection =
-    reportDefinitionDetails.triggerType === 'On demand' ? (
+    reportDefinitionDetails.triggerType === ON_DEMAND ? (
       <ReportDetailsComponent
         reportDetailsComponentTitle={'Trigger type'}
         reportDetailsComponentContent={reportDefinitionDetails.triggerType}

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -453,33 +453,6 @@ export function ReportDefinitionDetails(props) {
       </EuiFlexGroup>
     );
 
-  const showNotificationSection =
-    reportDefinitionDetails.triggerType === 'On demand' ? null : (
-      <div>
-        <EuiTitle>
-          <h3>Notification settings</h3>
-        </EuiTitle>
-        <EuiSpacer />
-        <EuiFlexGroup>
-          <ReportDetailsComponent
-            reportDetailsComponentTitle={'Email recipients'}
-            reportDetailsComponentContent={
-              reportDefinitionDetails.emailRecipients
-            }
-          />
-          <ReportDetailsComponent
-            reportDetailsComponentTitle={'Email subject'}
-            reportDetailsComponentContent={reportDefinitionDetails.emailSubject}
-          />
-          <ReportDetailsComponent
-            reportDetailsComponentTitle={'Optional message'}
-            reportDetailsComponentContent={reportDefinitionDetails.emailBody}
-          />
-          <ReportDetailsComponent />
-        </EuiFlexGroup>
-      </div>
-    );
-
   return (
     <EuiPage>
       <EuiPageBody>
@@ -592,7 +565,29 @@ export function ReportDefinitionDetails(props) {
           <EuiSpacer />
           {triggerSection}
           <EuiSpacer />
-          {showNotificationSection}
+          <EuiTitle>
+            <h3>Notification settings</h3>
+          </EuiTitle>
+          <EuiSpacer />
+          <EuiFlexGroup>
+            <ReportDetailsComponent
+              reportDetailsComponentTitle={'Email recipients'}
+              reportDetailsComponentContent={
+                reportDefinitionDetails.emailRecipients
+              }
+            />
+            <ReportDetailsComponent
+              reportDetailsComponentTitle={'Email subject'}
+              reportDetailsComponentContent={
+                reportDefinitionDetails.emailSubject
+              }
+            />
+            <ReportDetailsComponent
+              reportDetailsComponentTitle={'Optional message'}
+              reportDetailsComponentContent={reportDefinitionDetails.emailBody}
+            />
+            <ReportDetailsComponent />
+          </EuiFlexGroup>
         </EuiPageContent>
         <EuiGlobalToastList
           toasts={toasts}


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Schedule details are in human-readable format 
* `Delivery settings` section changed to `Notification settings`
* `Notification settings` only display for Scheduled report definitions
* `Report trigger` display shows details for scheduled reports but only shows trigger type for on-demand reports 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
