### PR TITLE
Create/Edit Bug Fixes

### DIFF
--- a/kibana-reports/public/components/main/main.tsx
+++ b/kibana-reports/public/components/main/main.tsx
@@ -102,6 +102,34 @@ export function Main(props) {
     addSuccessOnDemandDownloadToastHandler();
   };
 
+  const addCreateReportDefinitionSuccessToastHandler = () => {
+    const successToast = {
+      title: 'Success',
+      color: 'success',
+      text: <p>Report definition successfully created!</p>,
+      id: 'createReportDefinitionSuccessToast',
+    };
+    setToasts(toasts.concat(successToast));
+  };
+
+  const handleCreateReportDefinitionSuccessToast = () => {
+    addCreateReportDefinitionSuccessToastHandler();
+  };
+
+  const addEditReportDefinitionSuccessToastHandler = () => {
+    const successToast = {
+      title: 'Success',
+      color: 'success',
+      text: <p>Report definition successfully updated!</p>,
+      id: 'editReportDefinitionSuccessToast',
+    };
+    setToasts(toasts.concat(successToast));
+  };
+
+  const handleEditReportDefinitionSuccessToast = () => {
+    addEditReportDefinitionSuccessToastHandler();
+  };
+
   const removeToast = (removedToast) => {
     setToasts(toasts.filter((toast) => toast.id !== removedToast.id));
   };
@@ -142,6 +170,13 @@ export function Main(props) {
         console.log('error when fetching all report definitions: ', error);
         handleReportDefinitionsTableErrorToast();
       });
+
+    if (window.location.href.includes('create=success')) {
+      handleCreateReportDefinitionSuccessToast();
+    } else if (window.location.href.includes('edit=success')) {
+      handleEditReportDefinitionSuccessToast();
+    }
+    window.location.href = 'opendistro_kibana_reports#/';
   }, []);
 
   const refreshReportsTable = async () => {

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -34,6 +34,7 @@ import { ReportDetailsComponent } from '../report_details/report_details';
 import { fileFormatsUpper, generateReport } from '../main_utils';
 import { ReportDefinitionSchemaType } from '../../../../server/model';
 import moment from 'moment';
+import { converter } from '../../report_definitions/utils';
 
 const ON_DEMAND = 'On demand';
 
@@ -258,10 +259,10 @@ export function ReportDefinitionDetails(props) {
       timePeriod: moment.duration(timeDuration).humanize(),
       fileFormat: reportFormat,
       reportHeader: reportParams.core_params.hasOwnProperty('header')
-        ? reportParams.core_params.header
+        ? converter.makeMarkdown(reportParams.core_params.header)
         : `\u2014`,
       reportFooter: reportParams.core_params.hasOwnProperty('footer')
-        ? reportParams.core_params.footer
+        ? converter.makeMarkdown(reportParams.core_params.footer)
         : `\u2014`,
       triggerType: triggerType,
       scheduleDetails: triggerParams

--- a/kibana-reports/public/components/main/report_details/report_details.tsx
+++ b/kibana-reports/public/components/main/report_details/report_details.tsx
@@ -35,6 +35,7 @@ import {
 } from '@elastic/eui';
 import { fileFormatsUpper, generateReportById } from '../main_utils';
 import { ReportSchemaType } from '../../../../server/model';
+import { converter } from '../../report_definitions/utils';
 
 export const ReportDetailsComponent = (props) => {
   const { reportDetailsComponentTitle, reportDetailsComponentContent } = props;
@@ -136,11 +137,11 @@ export function ReportDetails(props) {
       state: state,
       reportHeader:
         reportParams.core_params.header != ''
-          ? reportParams.core_params.header
+          ? converter.makeMarkdown(reportParams.core_params.header)
           : `\u2014`,
       reportFooter:
         reportParams.core_params.footer != ''
-          ? reportParams.core_params.footer
+          ? converter.makeMarkdown(reportParams.core_params.footer)
           : `\u2014`,
       triggerType: triggerType,
       scheduleType: triggerParams ? triggerParams.schedule_type : `\u2014`,
@@ -194,9 +195,16 @@ export function ReportDetails(props) {
     let formatUpper = data['defaultFileFormat'];
     formatUpper = fileFormatsUpper[formatUpper];
     return (
-      <EuiLink onClick={() => {
-        generateReportById(reportId, props.httpClient, handleSuccessToast, handleErrorToast);
-      }}>
+      <EuiLink
+        onClick={() => {
+          generateReportById(
+            reportId,
+            props.httpClient,
+            handleSuccessToast,
+            handleErrorToast
+          );
+        }}
+      >
         {formatUpper + ' '}
         <EuiIcon type="importAction" />
       </EuiLink>

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -29,6 +29,7 @@ import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
 import { generateReport } from '../../main/main_utils';
 import { isValidCron } from 'cron-validator';
+import { converter } from '../utils';
 import moment from 'moment';
 
 interface reportParamsType {
@@ -152,20 +153,6 @@ export function CreateReport(props) {
     addErrorToastHandler();
   };
 
-  const addSuccessToastHandler = () => {
-    const successToast = {
-      title: 'Success',
-      color: 'success',
-      text: <p>Report definition successfully created!</p>,
-      id: 'successToast',
-    };
-    setToasts(toasts.concat(successToast));
-  };
-
-  const handleSuccessToast = () => {
-    addSuccessToastHandler();
-  };
-
   const addInvalidTimeRangeToastHandler = () => {
     const errorToast = {
       title: 'Invalid time range selected',
@@ -275,6 +262,17 @@ export function CreateReport(props) {
       setPreErrorData(metadata);
       setComingFromError(true);
     } else {
+      // convert header and footer to html
+      if ('header' in metadata.report_params.core_params) {
+        metadata.report_params.core_params.header = converter.makeHtml(
+          metadata.report_params.core_params.header
+        );
+      }
+      if ('footer' in metadata.report_params.core_params) {
+        metadata.report_params.core_params.footer = converter.makeHtml(
+          metadata.report_params.core_params.footer
+        );
+      }
       httpClient
         .post('../api/reporting/reportDefinition', {
           body: JSON.stringify(metadata),
@@ -295,8 +293,8 @@ export function CreateReport(props) {
             };
             generateReport(onDemandDownloadMetadata, httpClient);
           }
-          await handleSuccessToast();
-          window.location.assign(`opendistro_kibana_reports#/`);
+          // await handleSuccessToast();
+          window.location.assign(`opendistro_kibana_reports#/create=success`);
         })
         .catch((error) => {
           console.log('error in creating report definition: ' + error);
@@ -306,6 +304,7 @@ export function CreateReport(props) {
   };
 
   useEffect(() => {
+    window.scrollTo(0, 0);
     props.setBreadcrumbs([
       {
         text: 'Reporting',
@@ -351,7 +350,7 @@ export function CreateReport(props) {
           <EuiFlexItem grow={false}>
             <EuiButtonEmpty
               onClick={() => {
-                window.location.assign(`opendistro_kibana_reports#/${true}`);
+                window.location.assign(`opendistro_kibana_reports#/`);
               }}
             >
               Cancel

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -293,7 +293,6 @@ export function CreateReport(props) {
             };
             generateReport(onDemandDownloadMetadata, httpClient);
           }
-          // await handleSuccessToast();
           window.location.assign(`opendistro_kibana_reports#/create=success`);
         })
         .catch((error) => {

--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -29,6 +29,7 @@ import { ReportSettings } from '../report_settings';
 import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
 import { ReportDefinitionSchemaType } from 'server/model';
+import { converter } from '../utils';
 
 export function EditReportDefinition(props) {
   const [toasts, setToasts] = useState([]);
@@ -104,7 +105,7 @@ export function EditReportDefinition(props) {
         params: reportDefinitionId.toString(),
       })
       .then(async () => {
-        window.location.assign(`opendistro_kibana_reports#/`);
+        window.location.assign(`opendistro_kibana_reports#/edit=success`);
       })
       .catch((error) => {
         console.error('error in updating report definition:', error);
@@ -114,6 +115,16 @@ export function EditReportDefinition(props) {
 
   const editReportDefinition = async (metadata) => {
     const { httpClient } = props;
+    if ('header' in metadata.report_params.core_params) {
+      metadata.report_params.core_params.header = converter.makeHtml(
+        metadata.report_params.core_params.header
+      );
+    }
+    if ('footer' in metadata.report_params.core_params) {
+      metadata.report_params.core_params.footer = converter.makeHtml(
+        metadata.report_params.core_params.footer
+      );
+    }
     /*
       we check if this editing updates the trigger type from Schedule to On demand. 
       If so, need to first delete the reportDefinition along with the scheduled job first, by calling the delete
@@ -144,6 +155,7 @@ export function EditReportDefinition(props) {
   };
 
   useEffect(() => {
+    window.scrollTo(0, 0);
     const { httpClient } = props;
     httpClient
       .get(`../api/reporting/reportDefinitions/${reportDefinitionId}`)

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -230,16 +230,12 @@ export function ReportSettings(props: ReportSettingProps) {
 
     const handleHeader = (e) => {
       setHeader(e);
-      reportDefinitionRequest.report_params.core_params.header = converter.makeHtml(
-        e
-      );
+      reportDefinitionRequest.report_params.core_params.header = e;
     };
 
     const handleFooter = (e) => {
       setFooter(e);
-      reportDefinitionRequest.report_params.core_params.footer = converter.makeHtml(
-        e
-      );
+      reportDefinitionRequest.report_params.core_params.footer = e;
     };
 
     const handleCheckboxHeaderFooter = (optionId) => {
@@ -311,7 +307,7 @@ export function ReportSettings(props: ReportSettingProps) {
             if (footer) {
               checkboxIdSelectHeaderFooter.footer = true;
               if (!unmounted) {
-                setFooter(converter.makeMarkdown(header));
+                setFooter(converter.makeMarkdown(footer));
               }
             }
           })
@@ -322,12 +318,15 @@ export function ReportSettings(props: ReportSettingProps) {
             );
           });
       } else {
-        if (reportDefinitionRequest.report_params.core_params.header != '') {
-          checkboxIdSelectHeaderFooter.header = true;
+        // keeps header/footer from re-rendering empty when other fields in Report Settings are changed
+        checkboxIdSelectHeaderFooter.header =
+          'header' in reportDefinitionRequest.report_params.core_params;
+        checkboxIdSelectHeaderFooter.footer =
+          'footer' in reportDefinitionRequest.report_params.core_params;
+        if (checkboxIdSelectHeaderFooter.header) {
           setHeader(reportDefinitionRequest.report_params.core_params.header);
         }
-        if (reportDefinitionRequest.report_params.core_params.footer != '') {
-          checkboxIdSelectHeaderFooter.footer = true;
+        if (checkboxIdSelectHeaderFooter.footer) {
           setFooter(reportDefinitionRequest.report_params.core_params.footer);
         }
       }

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -53,11 +53,11 @@ export const SAVED_SEARCH_FORMAT_OPTIONS = [
 export const HEADER_FOOTER_CHECKBOX = [
   {
     id: 'header',
-    label: 'Header',
+    label: 'Add header',
   },
   {
     id: 'footer',
-    label: 'Footer',
+    label: 'Add footer',
   },
 ];
 export const REPORT_SOURCE_TYPES = {

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger_constants.tsx
@@ -31,7 +31,7 @@ export const SCHEDULE_TYPE_OPTIONS = [
   },
   {
     id: 'Cron based',
-    label: 'Cron based',
+    label: 'Cron-based',
   },
 ];
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Checkboxes for `Header` and `Footer` are now `Add header` and `Add footer`
* Create and Edit pages start at the top of the page on redirect
* Add header/footer is not selected by default
* Toasts pop up on the landing page after redirect after a successful create/edit report definition
* `Start time` and scheduling options pre-populate correctly on `Edit`
* `Cron based` changed to `Cron-based`
* Changing the start time in `Recurring` in `Report trigger` no longer resets other fields
* Header/footer values do not change to raw HTML in Create/Edit
* Header/footer is parsed into HTML before requests are sent to the server-side
* Header/footer text is displayed in markdown format in the `Details` pages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
