### PR TITLE
Preserve Pre-error Edit state on Invalid Update

### DIFF
--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -33,6 +33,8 @@ import { converter } from '../utils';
 
 export function EditReportDefinition(props) {
   const [toasts, setToasts] = useState([]);
+  const [comingFromError, setComingFromError] = useState(false);
+  const [preErrorData, setPreErrorData] = useState({});
 
   const addErrorUpdatingReportDefinitionToast = () => {
     const errorToast = {
@@ -90,11 +92,16 @@ export function EditReportDefinition(props) {
     last_updated: 0,
     status: '',
   };
+  reportDefinition = editReportDefinitionRequest; // initialize reportDefinition object
 
   let timeRange = {
     timeFrom: new Date(),
     timeTo: new Date(),
   };
+
+  if (comingFromError) {
+    editReportDefinitionRequest = preErrorData;
+  }
 
   const callUpdateAPI = async (metadata) => {
     const { httpClient } = props;
@@ -110,6 +117,8 @@ export function EditReportDefinition(props) {
       .catch((error) => {
         console.error('error in updating report definition:', error);
         handleErrorUpdatingReportDefinitionToast();
+        setPreErrorData(metadata);
+        setComingFromError(true);
       });
   };
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Preserve the state of the edit report definition data when an invalid update is sent so the user can re-submit after correcting the error 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
