### PR TITLE
Fix "open in Kibana" link issue in embedded html of email body

### DIFF
--- a/kibana-reports/server/routes/utils/notification/deliveryContentHelper.ts
+++ b/kibana-reports/server/routes/utils/notification/deliveryContentHelper.ts
@@ -31,7 +31,8 @@ export const composeEmbeddedHtml = (
   const $ = cheerio.load(
     fs.readFileSync(
       `${__dirname}/notification_content_template/email_content_template.html`
-    )
+    ),
+    { decodeEntities: false }
   );
   // set each link and logo
   $('.logo').attr('src', `data:image/png;base64,${logoAsBase64}`);


### PR DESCRIPTION
*Issue #, if available:*
The link fails to lead to the right page, because the url contains single quotes is decoded to `&apos;`

```
http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:&apos;2020-10-24T00:00:04.482Z&apos;,to:&apos;2020-10-24T00:15:04.483Z&apos;))
```

*Description of changes:*
- turn off `Cherrio` default setting to decode HTML entities

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
