### PR TITLE
remove "refresh interval" option from time selector

### DIFF
--- a/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -37,8 +37,6 @@ export function TimeRangeSelect(props) {
   const [isLoading, setIsLoading] = useState(false);
   const [start, setStart] = useState('now-30m');
   const [end, setEnd] = useState('now');
-  const [isPaused, setIsPaused] = useState(true);
-  const [refreshInterval, setRefreshInterval] = useState();
 
   const [toasts, setToasts] = useState([]);
 
@@ -185,25 +183,12 @@ export function TimeRangeSelect(props) {
     reportDefinitionRequest.report_params.core_params.time_duration = timeDuration.toISOString();
   };
 
-  const onRefresh = ({ start, end, refreshInterval }) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, 100);
-    }).then(() => {
-      console.log(start, end, refreshInterval);
-    });
-  };
-
   const startLoading = () => {
     setTimeout(stopLoading, 1000);
   };
 
   const stopLoading = () => {
     setIsLoading(false);
-  };
-
-  const onRefreshChange = ({ isPaused, refreshInterval }) => {
-    setIsPaused(isPaused);
-    setRefreshInterval(refreshInterval);
   };
 
   return (
@@ -220,11 +205,6 @@ export function TimeRangeSelect(props) {
             start={start}
             end={end}
             onTimeChange={onTimeChange}
-            onRefresh={onRefresh}
-            isPaused={isPaused}
-            refreshInterval={refreshInterval}
-            onRefreshChange={onRefreshChange}
-            recentlyUsedRanges={recentlyUsedRanges}
             showUpdateButton={false}
           />
         </EuiFormRow>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
remove the "refresh interval" options from time selector in "create report definition", because we don't need it.
![image](https://user-images.githubusercontent.com/32652829/97259047-11dc7480-17d7-11eb-85eb-cd47891cc928.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
