### PR TITLE
Fix Warning on Report Details Test 

### DIFF
--- a/kibana-reports/public/components/main/report_details/__tests__/__snapshots__/report_details.test.tsx.snap
+++ b/kibana-reports/public/components/main/report_details/__tests__/__snapshots__/report_details.test.tsx.snap
@@ -506,7 +506,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             >
               <h2
                 class="euiTitle euiTitle--medium"
-              />
+              >
+                test create report definition trigger
+              </h2>
             </div>
           </div>
         </div>
@@ -538,7 +540,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              test create report definition trigger
+            </dd>
           </dl>
         </div>
         <div
@@ -554,7 +558,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -570,7 +576,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -586,7 +594,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
       </div>
@@ -612,10 +622,12 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             >
               <a
                 class="euiLink euiLink--primary"
-                href="localhostundefined"
+                href="localhosthttp://localhost:5601/app/kibana#/dashboard/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))"
                 rel="noopener noreferrer"
                 target="_blank"
-              />
+              >
+                Dashboard
+              </a>
             </dd>
           </dl>
         </div>
@@ -632,7 +644,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              10/23/2020, 1:53:35 PM -&gt; 10/23/2020, 2:23:35 PM
+            </dd>
           </dl>
         </div>
         <div
@@ -779,7 +793,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              On demand
+            </dd>
           </dl>
         </div>
         <div
@@ -795,7 +811,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -811,7 +829,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -856,7 +876,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -872,7 +894,9 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              —
+            </dd>
           </dl>
         </div>
         <div
@@ -888,7 +912,11 @@ exports[`<ReportDetails /> panel render on-demand component 1`] = `
             </dt>
             <dd
               class="euiDescriptionList__description"
-            />
+            >
+              <p>
+                —
+              </p>
+            </dd>
           </dl>
         </div>
         <div

--- a/kibana-reports/public/components/main/report_details/__tests__/report_details.test.tsx
+++ b/kibana-reports/public/components/main/report_details/__tests__/report_details.test.tsx
@@ -21,6 +21,10 @@ import httpClientMock from '../../../../../test/httpMockClient';
 import 'babel-polyfill';
 import { act } from 'react-dom/test-utils';
 
+function setBreadcrumbs(array: []) {
+  jest.fn();
+}
+
 describe('<ReportDetails /> panel', () => {
   const match = {
     params: {
@@ -40,7 +44,7 @@ describe('<ReportDetails /> panel', () => {
           report_format: '',
           header: '',
           footer: '',
-          time_duration: '',
+          time_duration: 'PT30M',
         },
       },
       delivery: {
@@ -54,17 +58,19 @@ describe('<ReportDetails /> panel', () => {
 
     httpClientMock.get = jest.fn().mockResolvedValue({
       report_definition,
+      query_url: `http://localhost:5601/app/kibana#/dashboard/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))`,
     });
 
-    const { container } = await render(
+    const { container } = render(
       <ReportDetails
         httpClient={httpClientMock}
         props={propsMock}
         match={match}
+        setBreadcrumbs={setBreadcrumbs}
       />
     );
-    await expect(container.firstChild).toMatchSnapshot();
     await act(() => promise);
+    await expect(container.firstChild).toMatchSnapshot();
   });
 
   test('render 5 hours recurring component', async () => {
@@ -79,7 +85,7 @@ describe('<ReportDetails /> panel', () => {
           report_format: '',
           header: '',
           footer: '',
-          time_duration: '',
+          time_duration: 'PT30M',
         },
       },
       delivery: {
@@ -108,14 +114,15 @@ describe('<ReportDetails /> panel', () => {
       query_url: `http://localhost:5601/app/kibana#/dashboard/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(time:(from:'2020-10-23T20:53:35.315Z',to:'2020-10-23T21:23:35.316Z'))`,
     });
 
-    const { container } = await render(
+    const { container } = render(
       <ReportDetails
         httpClient={httpClientMock}
         props={propsMock}
         match={match}
+        setBreadcrumbs={setBreadcrumbs}
       />
     );
-    await expect(container.firstChild).toMatchSnapshot();
     await act(() => promise);
+    await expect(container.firstChild).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Silence a React warning about unwrapped state changes in `Report details` tests and forgetting to include `queryUrl` in one of the tests which threw a warning. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
