### PR TITLE
[Bug Fix] Configure fixed timezone for jest testing

### DIFF
--- a/kibana-reports/test/jest.config.js
+++ b/kibana-reports/test/jest.config.js
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+process.env.TZ = 'America/Los_Angeles';
+
 module.exports = {
   rootDir: '../',
   setUpFiles: ['<rootDir>/test/setupTests.ts'],


### PR DESCRIPTION
*Issue #, if available:*
github action CI has test failures, while local testing is fine. It's due to github action is using UTC as timezone, while our testing is using `America/LA`

*Description of changes:*
Configure fixed timezone for snapshot jest testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
