### PR TITLE
Pagination support for list APIs

### DIFF
--- a/reports-scheduler/src/main/config/reports-scheduler.yml
+++ b/reports-scheduler/src/main/config/reports-scheduler.yml
@@ -24,3 +24,4 @@ opendistro.reports.scheduler:
     minPollingDurationSeconds: 300 # 5 Minutes, Minimum 60 seconds
     maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
     maxLockRetries: 1 # Max number of retries to retry locking
+    defaultItemsQueryCount: 100 # default number of items to query

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/ReportDefinitionActions.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/ReportDefinitionActions.kt
@@ -122,9 +122,9 @@ internal object ReportDefinitionActions {
      * @return [GetAllReportDefinitionsResponse]
      */
     fun getAll(request: GetAllReportDefinitionsRequest): GetAllReportDefinitionsResponse {
-        log.info("$LOG_PREFIX:ReportDefinition-getAll ${request.fromIndex}")
+        log.info("$LOG_PREFIX:ReportDefinition-getAll fromIndex:${request.fromIndex} maxItems:${request.maxItems}")
         // TODO verify actual requester ID
-        val reportDefinitionsList = ReportDefinitionsIndex.getAllReportDefinitions(listOf(TEMP_ROLE_ID), request.fromIndex)
+        val reportDefinitionsList = ReportDefinitionsIndex.getAllReportDefinitions(listOf(TEMP_ROLE_ID), request.fromIndex, request.maxItems)
         return GetAllReportDefinitionsResponse(reportDefinitionsList)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/ReportInstanceActions.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/ReportInstanceActions.kt
@@ -143,9 +143,9 @@ internal object ReportInstanceActions {
      * @return [GetAllReportInstancesResponse]
      */
     fun getAll(request: GetAllReportInstancesRequest): GetAllReportInstancesResponse {
-        log.info("$LOG_PREFIX:ReportInstance-getAll ${request.fromIndex}")
+        log.info("$LOG_PREFIX:ReportInstance-getAll fromIndex:${request.fromIndex} maxItems:${request.maxItems}")
         // TODO verify actual requester ID
-        val reportInstanceList = ReportInstancesIndex.getAllReportInstances(listOf(TEMP_ROLE_ID), request.fromIndex)
+        val reportInstanceList = ReportInstancesIndex.getAllReportInstances(listOf(TEMP_ROLE_ID), request.fromIndex, request.maxItems)
         return GetAllReportInstancesResponse(reportInstanceList)
     }
 

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/GetAllReportDefinitionsResponse.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/GetAllReportDefinitionsResponse.kt
@@ -16,18 +16,13 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.model
 
-import com.amazon.opendistroforelasticsearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
-import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.REPORT_DEFINITION_LIST_FIELD
 import com.amazon.opendistroforelasticsearch.reportsscheduler.util.createJsonParser
-import com.amazon.opendistroforelasticsearch.reportsscheduler.util.logger
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentFactory
 import org.elasticsearch.common.xcontent.XContentParser
-import org.elasticsearch.common.xcontent.XContentParser.Token
-import org.elasticsearch.common.xcontent.XContentParserUtils
 import java.io.IOException
 
 /**
@@ -35,6 +30,9 @@ import java.io.IOException
  * <pre> JSON format
  * {@code
  * {
+ *   "startIndex":"0",
+ *   "totalHits":"100",
+ *   "totalHitRelation":"eq",
  *   "reportDefinitionDetailsList":[
  *      // refer [com.amazon.opendistroforelasticsearch.reportsscheduler.model.ReportDefinitionDetails]
  *   ]
@@ -42,9 +40,9 @@ import java.io.IOException
  * }</pre>
  */
 internal class GetAllReportDefinitionsResponse : BaseResponse {
-    val reportDefinitionList: List<ReportDefinitionDetails>
+    val reportDefinitionList: ReportDefinitionDetailsSearchResults
 
-    constructor(reportDefinitionList: List<ReportDefinitionDetails>) : super() {
+    constructor(reportDefinitionList: ReportDefinitionDetailsSearchResults) : super() {
         this.reportDefinitionList = reportDefinitionList
     }
 
@@ -56,39 +54,7 @@ internal class GetAllReportDefinitionsResponse : BaseResponse {
      * @param parser data referenced at parser
      */
     constructor(parser: XContentParser) : super() {
-        var reportDefinitions: List<ReportDefinitionDetails>? = null
-        XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation)
-        while (Token.END_OBJECT != parser.nextToken()) {
-            val fieldName = parser.currentName()
-            parser.nextToken()
-            when (fieldName) {
-                REPORT_DEFINITION_LIST_FIELD -> reportDefinitions = parseReportDefinitionList(parser)
-                else -> {
-                    parser.skipChildren()
-                    log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
-                }
-            }
-        }
-        reportDefinitions ?: throw IllegalArgumentException("$REPORT_DEFINITION_LIST_FIELD field absent")
-        this.reportDefinitionList = reportDefinitions
-    }
-
-    companion object {
-        private val log by logger(GetAllReportDefinitionsResponse::class.java)
-
-        /**
-         * Parse the report definition list from parser
-         * @param parser data referenced at parser
-         * @return created list of ReportDefinitionDetails
-         */
-        private fun parseReportDefinitionList(parser: XContentParser): List<ReportDefinitionDetails> {
-            val retList: MutableList<ReportDefinitionDetails> = mutableListOf()
-            XContentParserUtils.ensureExpectedToken(Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation)
-            while (parser.nextToken() != Token.END_ARRAY) {
-                retList.add(ReportDefinitionDetails.parse(parser))
-            }
-            return retList
-        }
+        reportDefinitionList = ReportDefinitionDetailsSearchResults(parser)
     }
 
     /**
@@ -103,9 +69,6 @@ internal class GetAllReportDefinitionsResponse : BaseResponse {
      * {@inheritDoc}
      */
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        builder!!.startObject()
-            .startArray(REPORT_DEFINITION_LIST_FIELD)
-        reportDefinitionList.forEach { it.toXContent(builder, ToXContent.EMPTY_PARAMS, true) }
-        return builder.endArray().endObject()
+        return reportDefinitionList.toXContent(builder, params)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/GetAllReportInstancesRequest.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/GetAllReportInstancesRequest.kt
@@ -18,6 +18,8 @@ package com.amazon.opendistroforelasticsearch.reportsscheduler.model
 
 import com.amazon.opendistroforelasticsearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.FROM_INDEX_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.MAX_ITEMS_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings
 import com.amazon.opendistroforelasticsearch.reportsscheduler.util.logger
 import org.elasticsearch.action.ActionRequest
 import org.elasticsearch.action.ActionRequestValidationException
@@ -38,17 +40,20 @@ import java.io.IOException
  * <pre> JSON format
  * {@code
  * {
- *   "fromIndex":100
+ *   "fromIndex":100,
+ *   "maxItems":100
  * }
  * }</pre>
  */
 internal data class GetAllReportInstancesRequest(
-    val fromIndex: Int
+    val fromIndex: Int,
+    val maxItems: Int
 ) : ActionRequest(), ToXContentObject {
 
     @Throws(IOException::class)
     constructor(input: StreamInput) : this(
-        fromIndex = input.readInt()
+        fromIndex = input.readInt(),
+        maxItems = input.readInt()
     )
 
     companion object {
@@ -60,20 +65,22 @@ internal data class GetAllReportInstancesRequest(
          * @return created [GetAllReportInstancesRequest] object
          */
         fun parse(parser: XContentParser): GetAllReportInstancesRequest {
-            var reportInstanceId = 0
+            var fromIndex = 0
+            var maxItems = PluginSettings.defaultItemsQueryCount
             XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation)
             while (Token.END_OBJECT != parser.nextToken()) {
                 val fieldName = parser.currentName()
                 parser.nextToken()
                 when (fieldName) {
-                    FROM_INDEX_FIELD -> reportInstanceId = parser.intValue()
+                    FROM_INDEX_FIELD -> fromIndex = parser.intValue()
+                    MAX_ITEMS_FIELD -> maxItems = parser.intValue()
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
                     }
                 }
             }
-            return GetAllReportInstancesRequest(reportInstanceId)
+            return GetAllReportInstancesRequest(fromIndex, maxItems)
         }
     }
 
@@ -83,6 +90,7 @@ internal data class GetAllReportInstancesRequest(
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         output.writeInt(fromIndex)
+        output.writeInt(maxItems)
     }
 
     /**
@@ -112,6 +120,7 @@ internal data class GetAllReportInstancesRequest(
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
         return builder!!.startObject()
             .field(FROM_INDEX_FIELD, fromIndex)
+            .field(MAX_ITEMS_FIELD, maxItems)
             .endObject()
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/GetAllReportInstancesResponse.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/GetAllReportInstancesResponse.kt
@@ -16,18 +16,13 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.model
 
-import com.amazon.opendistroforelasticsearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
-import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.REPORT_INSTANCE_LIST_FIELD
 import com.amazon.opendistroforelasticsearch.reportsscheduler.util.createJsonParser
-import com.amazon.opendistroforelasticsearch.reportsscheduler.util.logger
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentFactory
 import org.elasticsearch.common.xcontent.XContentParser
-import org.elasticsearch.common.xcontent.XContentParser.Token
-import org.elasticsearch.common.xcontent.XContentParserUtils
 import java.io.IOException
 
 /**
@@ -35,6 +30,9 @@ import java.io.IOException
  * <pre> JSON format
  * {@code
  * {
+ *   "startIndex":"0",
+ *   "totalHits":"100",
+ *   "totalHitRelation":"eq",
  *   "reportInstanceList":[
  *      // refer [com.amazon.opendistroforelasticsearch.reportsscheduler.model.ReportInstance]
  *   ]
@@ -42,9 +40,9 @@ import java.io.IOException
  * }</pre>
  */
 internal class GetAllReportInstancesResponse : BaseResponse {
-    val reportInstanceList: List<ReportInstance>
+    val reportInstanceList: ReportInstanceSearchResults
 
-    constructor(reportInstanceList: List<ReportInstance>) : super() {
+    constructor(reportInstanceList: ReportInstanceSearchResults) : super() {
         this.reportInstanceList = reportInstanceList
     }
 
@@ -56,39 +54,7 @@ internal class GetAllReportInstancesResponse : BaseResponse {
      * @param parser data referenced at parser
      */
     constructor(parser: XContentParser) : super() {
-        var reportInstanceList: List<ReportInstance>? = null
-        XContentParserUtils.ensureExpectedToken(Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation)
-        while (Token.END_OBJECT != parser.nextToken()) {
-            val fieldName = parser.currentName()
-            parser.nextToken()
-            when (fieldName) {
-                REPORT_INSTANCE_LIST_FIELD -> reportInstanceList = parseReportInstanceList(parser)
-                else -> {
-                    parser.skipChildren()
-                    log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
-                }
-            }
-        }
-        reportInstanceList ?: throw IllegalArgumentException("$REPORT_INSTANCE_LIST_FIELD field absent")
-        this.reportInstanceList = reportInstanceList
-    }
-
-    companion object {
-        private val log by logger(GetAllReportInstancesResponse::class.java)
-
-        /**
-         * Parse the report instance list from parser
-         * @param parser data referenced at parser
-         * @return created list of ReportInstance
-         */
-        private fun parseReportInstanceList(parser: XContentParser): List<ReportInstance> {
-            val retList: MutableList<ReportInstance> = mutableListOf()
-            XContentParserUtils.ensureExpectedToken(Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation)
-            while (parser.nextToken() != Token.END_ARRAY) {
-                retList.add(ReportInstance.parse(parser))
-            }
-            return retList
-        }
+        this.reportInstanceList = ReportInstanceSearchResults(parser)
     }
 
     /**
@@ -103,9 +69,6 @@ internal class GetAllReportInstancesResponse : BaseResponse {
      * {@inheritDoc}
      */
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
-        builder!!.startObject()
-            .startArray(REPORT_INSTANCE_LIST_FIELD)
-        reportInstanceList.forEach { it.toXContent(builder, ToXContent.EMPTY_PARAMS, true) }
-        return builder.endArray().endObject()
+        return reportInstanceList.toXContent(builder, params)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportDefinitionDetailsSearchResults.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportDefinitionDetailsSearchResults.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.reportsscheduler.model
+
+import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.REPORT_DEFINITION_LIST_FIELD
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+
+/**
+ * ReportDefinitions search results
+ */
+internal class ReportDefinitionDetailsSearchResults : SearchResults<ReportDefinitionDetails> {
+    constructor(parser: XContentParser) : super(parser, REPORT_DEFINITION_LIST_FIELD)
+
+    constructor(from: Long, response: SearchResponse) : super(from, response, REPORT_DEFINITION_LIST_FIELD)
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun parseItem(parser: XContentParser, useId: String?): ReportDefinitionDetails {
+        return ReportDefinitionDetails.parse(parser, useId)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun itemToXContent(item: ReportDefinitionDetails, builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        item.toXContent(builder, ToXContent.EMPTY_PARAMS, true)
+        return builder
+    }
+}

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportInstanceSearchResults.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportInstanceSearchResults.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.reportsscheduler.model
+
+import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.REPORT_INSTANCE_LIST_FIELD
+import org.apache.lucene.search.TotalHits
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+
+/**
+ * ReportInstances search results
+ */
+internal class ReportInstanceSearchResults : SearchResults<ReportInstance> {
+    constructor(
+        startIndex: Long,
+        totalHits: Long,
+        totalHitRelation: TotalHits.Relation,
+        objectList: List<ReportInstance>
+    ) : super(startIndex, totalHits, totalHitRelation, objectList, REPORT_INSTANCE_LIST_FIELD)
+
+    constructor(parser: XContentParser) : super(parser, REPORT_INSTANCE_LIST_FIELD)
+
+    constructor(from: Long, response: SearchResponse) : super(from, response, REPORT_INSTANCE_LIST_FIELD)
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun parseItem(parser: XContentParser, useId: String?): ReportInstance {
+        return ReportInstance.parse(parser, useId)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun itemToXContent(item: ReportInstance, builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        item.toXContent(builder, ToXContent.EMPTY_PARAMS, true)
+        return builder
+    }
+}

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/RestTag.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/RestTag.kt
@@ -36,5 +36,6 @@ internal object RestTag {
     const val REPORT_DEFINITION_ID_FIELD = "reportDefinitionId"
     const val REPORT_DEFINITION_DETAILS_FIELD = "reportDefinitionDetails"
     const val FROM_INDEX_FIELD = "fromIndex"
+    const val MAX_ITEMS_FIELD = "maxItems"
     const val RETRY_AFTER_FIELD = "retryAfter"
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/SearchResults.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/SearchResults.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.reportsscheduler.model
+
+import com.amazon.opendistroforelasticsearch.reportsscheduler.ReportsSchedulerPlugin.Companion.LOG_PREFIX
+import com.amazon.opendistroforelasticsearch.reportsscheduler.util.logger
+import org.apache.lucene.search.TotalHits
+import org.apache.lucene.search.TotalHits.Relation
+import org.apache.lucene.search.TotalHits.Relation.EQUAL_TO
+import org.apache.lucene.search.TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.ToXContent.Params
+import org.elasticsearch.common.xcontent.ToXContentObject
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParserUtils
+import org.elasticsearch.common.xcontent.XContentType
+
+internal abstract class SearchResults<ItemClass : ToXContentObject> : ToXContentObject {
+    val startIndex: Long
+    val totalHits: Long
+    val totalHitRelation: Relation
+    val objectList: List<ItemClass>
+    val objectListFieldName: String
+
+    companion object {
+        private val log by logger(SearchResults::class.java)
+        private const val START_INDEX_TAG = "startIndex"
+        private const val TOTAL_HITS_TAG = "totalHits"
+        private const val TOTAL_HIT_RELATION_TAG = "totalHitRelation"
+        private fun convertRelation(totalHitRelation: Relation): String {
+            return if (totalHitRelation == EQUAL_TO) {
+                "eq"
+            } else {
+                "gte"
+            }
+        }
+
+        private fun convertRelation(totalHitRelation: String): Relation {
+            return if (totalHitRelation == "eq") {
+                EQUAL_TO
+            } else {
+                GREATER_THAN_OR_EQUAL_TO
+            }
+        }
+    }
+
+    constructor(
+        startIndex: Long,
+        totalHits: Long,
+        totalHitRelation: Relation,
+        objectList: List<ItemClass>,
+        objectListFieldName: String
+    ) {
+        this.startIndex = startIndex
+        this.totalHits = totalHits
+        this.totalHitRelation = totalHitRelation
+        this.objectList = objectList
+        this.objectListFieldName = objectListFieldName
+    }
+
+    constructor(from: Long, response: SearchResponse, objectListFieldName: String) {
+        val mutableList: MutableList<ItemClass> = mutableListOf()
+        response.hits.forEach {
+            val parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                it.sourceAsString)
+            parser.nextToken()
+            mutableList.add(parseItem(parser, it.id))
+        }
+        val totalHits = response.hits.totalHits
+        val totalHitsVal: Long
+        val totalHitsRelation: TotalHits.Relation
+        if (totalHits == null) {
+            totalHitsVal = mutableList.size.toLong()
+            totalHitsRelation = TotalHits.Relation.EQUAL_TO
+        } else {
+            totalHitsVal = totalHits.value
+            totalHitsRelation = totalHits.relation
+        }
+        this.startIndex = from
+        this.totalHits = totalHitsVal
+        this.totalHitRelation = totalHitsRelation
+        this.objectList = mutableList
+        this.objectListFieldName = objectListFieldName
+    }
+
+    /**
+     * Parse the data from parser and create object
+     * @param parser data referenced at parser
+     */
+    constructor(parser: XContentParser, objectListFieldName: String) {
+        var startIndex: Long = 0
+        var totalHits: Long = 0
+        var totalHitRelation: Relation = EQUAL_TO
+        var objectList: List<ItemClass>? = null
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation)
+        while (XContentParser.Token.END_OBJECT != parser.nextToken()) {
+            val fieldName = parser.currentName()
+            parser.nextToken()
+            when (fieldName) {
+                START_INDEX_TAG -> startIndex = parser.longValue()
+                TOTAL_HITS_TAG -> totalHits = parser.longValue()
+                TOTAL_HIT_RELATION_TAG -> totalHitRelation = convertRelation(parser.text())
+                objectListFieldName -> objectList = parseItemList(parser)
+                else -> {
+                    parser.skipChildren()
+                    log.info("$LOG_PREFIX:Skipping Unknown field $fieldName")
+                }
+            }
+        }
+        objectList ?: throw IllegalArgumentException("$objectListFieldName field absent")
+        if (totalHits == 0L) {
+            totalHits = objectList.size.toLong()
+        }
+        this.startIndex = startIndex
+        this.totalHits = totalHits
+        this.totalHitRelation = totalHitRelation
+        this.objectList = objectList
+        this.objectListFieldName = objectListFieldName
+    }
+
+    /**
+     * Parse the item list from parser
+     * @param parser data referenced at parser
+     * @return created list of items
+     */
+    private fun parseItemList(parser: XContentParser): List<ItemClass> {
+        val retList: MutableList<ItemClass> = mutableListOf()
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation)
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            retList.add(parseItem(parser))
+        }
+        return retList
+    }
+
+    /**
+     * Parse the object item
+     * @param parser data referenced at parser
+     * @return created item
+     */
+    abstract fun parseItem(parser: XContentParser, useId: String? = null): ItemClass
+
+    /**
+     * {@inheritDoc}
+     */
+    open fun itemToXContent(item: ItemClass, builder: XContentBuilder, params: Params): XContentBuilder {
+        item.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        return builder
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
+        builder!!.startObject()
+            .field(START_INDEX_TAG, startIndex)
+            .field(TOTAL_HITS_TAG, totalHits)
+            .field(TOTAL_HIT_RELATION_TAG, convertRelation(totalHitRelation))
+            .startArray(objectListFieldName)
+        objectList.forEach { itemToXContent(it, builder, ToXContent.EMPTY_PARAMS) }
+        return builder.endArray().endObject()
+    }
+}

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/resthandler/ReportDefinitionListRestHandler.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/resthandler/ReportDefinitionListRestHandler.kt
@@ -20,6 +20,8 @@ import com.amazon.opendistroforelasticsearch.reportsscheduler.action.GetAllRepor
 import com.amazon.opendistroforelasticsearch.reportsscheduler.action.ReportDefinitionActions
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportDefinitionsRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.FROM_INDEX_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.MAX_ITEMS_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.rest.BaseRestHandler
 import org.elasticsearch.rest.BaseRestHandler.RestChannelConsumer
@@ -53,7 +55,7 @@ internal class ReportDefinitionListRestHandler : BaseRestHandler() {
         return listOf(
             /**
              * Get all report definitions (from optional fromIndex)
-             * Request URL: GET LIST_REPORT_DEFINITIONS_URL[?fromIndex=1000]
+             * Request URL: GET LIST_REPORT_DEFINITIONS_URL[?[fromIndex=1000]&[maxItems=100]]
              * Request body: None
              * Response body: Ref [com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportDefinitionsResponse]
              */
@@ -66,10 +68,11 @@ internal class ReportDefinitionListRestHandler : BaseRestHandler() {
      */
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val from = request.param(FROM_INDEX_FIELD)?.toIntOrNull() ?: 0
+        val maxItems = request.param(MAX_ITEMS_FIELD)?.toIntOrNull() ?: PluginSettings.defaultItemsQueryCount
         return when (request.method()) {
             GET -> RestChannelConsumer {
                 client.execute(GetAllReportDefinitionsAction.ACTION_TYPE,
-                    GetAllReportDefinitionsRequest(from),
+                    GetAllReportDefinitionsRequest(from, maxItems),
                     RestResponseToXContentListener(it))
             }
             else -> RestChannelConsumer {
@@ -82,6 +85,6 @@ internal class ReportDefinitionListRestHandler : BaseRestHandler() {
      * {@inheritDoc}
      */
     override fun responseParams(): Set<String> {
-        return setOf(FROM_INDEX_FIELD)
+        return setOf(FROM_INDEX_FIELD, MAX_ITEMS_FIELD)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/resthandler/ReportInstanceListRestHandler.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/resthandler/ReportInstanceListRestHandler.kt
@@ -20,6 +20,8 @@ import com.amazon.opendistroforelasticsearch.reportsscheduler.action.GetAllRepor
 import com.amazon.opendistroforelasticsearch.reportsscheduler.action.ReportInstanceActions
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportInstancesRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.FROM_INDEX_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.MAX_ITEMS_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.rest.BaseRestHandler
 import org.elasticsearch.rest.BaseRestHandler.RestChannelConsumer
@@ -53,7 +55,7 @@ internal class ReportInstanceListRestHandler : BaseRestHandler() {
         return listOf(
             /**
              * Get all report instances (from optional fromIndex)
-             * Request URL: GET LIST_REPORT_INSTANCES_URL[?fromIndex=1000]
+             * Request URL: GET LIST_REPORT_INSTANCES_URL[?[fromIndex=1000]&[maxItems=100]]
              * Request body: None
              * Response body: Ref [com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportInstancesResponse]
              */
@@ -65,7 +67,7 @@ internal class ReportInstanceListRestHandler : BaseRestHandler() {
      * {@inheritDoc}
      */
     override fun responseParams(): Set<String> {
-        return setOf(FROM_INDEX_FIELD)
+        return setOf(FROM_INDEX_FIELD, MAX_ITEMS_FIELD)
     }
 
     /**
@@ -73,10 +75,11 @@ internal class ReportInstanceListRestHandler : BaseRestHandler() {
      */
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val from = request.param(FROM_INDEX_FIELD)?.toIntOrNull() ?: 0
+        val maxItems = request.param(MAX_ITEMS_FIELD)?.toIntOrNull() ?: PluginSettings.defaultItemsQueryCount
         return when (request.method()) {
             GET -> RestChannelConsumer {
                 client.execute(GetAllReportInstancesAction.ACTION_TYPE,
-                    GetAllReportInstancesRequest(from),
+                    GetAllReportInstancesRequest(from, maxItems),
                     RestResponseToXContentListener(it))
             }
             else -> RestChannelConsumer {


### PR DESCRIPTION
*Issue #, if available:*NA

*Description of changes:*
Pagination support for list APIs
fromIndex and maxItems supported in request
response contains startIndex, totalHits and totalHitRelation(eq or gte)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
