### PR TITLE
Added user and backend role based access control to APIs

### DIFF
--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -113,7 +113,7 @@ plugins.withId('org.jetbrains.kotlin.jvm') {
 
 allprojects {
     group = "com.amazon.opendistroforelasticsearch"
-    version = "${opendistroVersion}.0"
+    version = "${opendistroVersion}.1"
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
@@ -126,7 +126,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     compile "${group}:common-utils:${version}"
-    compileOnly "${group}:opendistro-job-scheduler-spi:${version}"
+    compileOnly "${group}:opendistro-job-scheduler-spi:${opendistroVersion}.0" // TODO: use ${version} when available
     compile group: 'com.google.guava', name: 'guava', version: '15.0'
     testImplementation(
             'org.assertj:assertj-core:3.16.1',

--- a/reports-scheduler/gradle.properties
+++ b/reports-scheduler/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 1.10.1
+version = 1.11.0

--- a/reports-scheduler/src/main/config/reports-scheduler.yml
+++ b/reports-scheduler/src/main/config/reports-scheduler.yml
@@ -16,7 +16,7 @@
 ##
 
 # configuration file for the reports scheduler plugin
-opendistro.reports.scheduler:
+opendistro.reports:
   general:
     operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
   polling:
@@ -25,3 +25,13 @@ opendistro.reports.scheduler:
     maxPollingDurationSeconds: 900 # 15 Minutes, Minimum 5 Minutes
     maxLockRetries: 1 # Max number of retries to retry locking
     defaultItemsQueryCount: 100 # default number of items to query
+  access:
+    adminAccess: "AllReports"
+    # adminAccess values:
+    ## Standard -> Admin user access follows standard user
+    ## AllReports -> Admin user with "all_access" role can see all reports of all users.
+    filterBy: "NoFilter"
+    # filterBy values:
+    ## NoFilter -> everyone see each other's reports
+    ## User -> reports are visible to only themselves
+    ## BackendRoles -> reports are visible to users having any one of the backend role of creator

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/ReportsSchedulerPlugin.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/ReportsSchedulerPlugin.kt
@@ -41,7 +41,6 @@ import com.amazon.opendistroforelasticsearch.reportsscheduler.resthandler.Report
 import com.amazon.opendistroforelasticsearch.reportsscheduler.scheduler.ReportDefinitionJobParser
 import com.amazon.opendistroforelasticsearch.reportsscheduler.scheduler.ReportDefinitionJobRunner
 import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings
-import com.google.common.collect.ImmutableList
 import org.elasticsearch.action.ActionRequest
 import org.elasticsearch.action.ActionResponse
 import org.elasticsearch.client.Client
@@ -148,7 +147,7 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, JobSchedulerExtension {
         indexNameExpressionResolver: IndexNameExpressionResolver,
         nodesInCluster: Supplier<DiscoveryNodes>
     ): List<RestHandler> {
-        return ImmutableList.of<RestHandler>(
+        return listOf(
             ReportDefinitionRestHandler(),
             ReportDefinitionListRestHandler(),
             ReportInstanceRestHandler(),

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/CreateReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/CreateReportDefinitionAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.CreateReportDefinitionRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.CreateReportDefinitionResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class CreateReportDefinitionAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<CreateReportDefinitionRequest, CreateReportDefinitionResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::CreateReportDefinitionRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class CreateReportDefinitionAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: CreateReportDefinitionRequest): CreateReportDefinitionResponse {
-        return ReportDefinitionActions.create(request)
+    override fun executeRequest(request: CreateReportDefinitionRequest, user: User?): CreateReportDefinitionResponse {
+        return ReportDefinitionActions.create(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/DeleteReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/DeleteReportDefinitionAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.DeleteReportDefinitionRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.DeleteReportDefinitionResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class DeleteReportDefinitionAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<DeleteReportDefinitionRequest, DeleteReportDefinitionResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::DeleteReportDefinitionRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class DeleteReportDefinitionAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: DeleteReportDefinitionRequest): DeleteReportDefinitionResponse {
-        return ReportDefinitionActions.delete(request)
+    override fun executeRequest(request: DeleteReportDefinitionRequest, user: User?): DeleteReportDefinitionResponse {
+        return ReportDefinitionActions.delete(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetAllReportDefinitionsAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetAllReportDefinitionsAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportDefinitionsRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportDefinitionsResponse
 import org.elasticsearch.action.ActionType
@@ -30,22 +31,23 @@ import org.elasticsearch.transport.TransportService
  */
 internal class GetAllReportDefinitionsAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<GetAllReportDefinitionsRequest, GetAllReportDefinitionsResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::GetAllReportDefinitionsRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/definition/get_all"
+        private const val NAME = "cluster:admin/opendistro/reports/definition/list"
         internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportDefinitionsResponse)
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: GetAllReportDefinitionsRequest): GetAllReportDefinitionsResponse {
-        return ReportDefinitionActions.getAll(request)
+    override fun executeRequest(request: GetAllReportDefinitionsRequest, user: User?): GetAllReportDefinitionsResponse {
+        return ReportDefinitionActions.getAll(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetAllReportInstancesAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetAllReportInstancesAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportInstancesRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetAllReportInstancesResponse
 import org.elasticsearch.action.ActionType
@@ -30,22 +31,23 @@ import org.elasticsearch.transport.TransportService
  */
 internal class GetAllReportInstancesAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<GetAllReportInstancesRequest, GetAllReportInstancesResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::GetAllReportInstancesRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/reports/instance/get_all"
+        private const val NAME = "cluster:admin/opendistro/reports/instance/list"
         internal val ACTION_TYPE = ActionType(NAME, ::GetAllReportInstancesResponse)
     }
 
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: GetAllReportInstancesRequest): GetAllReportInstancesResponse {
-        return ReportInstanceActions.getAll(request)
+    override fun executeRequest(request: GetAllReportInstancesRequest, user: User?): GetAllReportInstancesResponse {
+        return ReportInstanceActions.getAll(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetReportDefinitionAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetReportDefinitionRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetReportDefinitionResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class GetReportDefinitionAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<GetReportDefinitionRequest, GetReportDefinitionResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::GetReportDefinitionRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class GetReportDefinitionAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: GetReportDefinitionRequest): GetReportDefinitionResponse {
-        return ReportDefinitionActions.info(request)
+    override fun executeRequest(request: GetReportDefinitionRequest, user: User?): GetReportDefinitionResponse {
+        return ReportDefinitionActions.info(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetReportInstanceAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/GetReportInstanceAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetReportInstanceRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.GetReportInstanceResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class GetReportInstanceAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<GetReportInstanceRequest, GetReportInstanceResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::GetReportInstanceRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class GetReportInstanceAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: GetReportInstanceRequest): GetReportInstanceResponse {
-        return ReportInstanceActions.info(request)
+    override fun executeRequest(request: GetReportInstanceRequest, user: User?): GetReportInstanceResponse {
+        return ReportInstanceActions.info(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/InContextReportCreateAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/InContextReportCreateAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.InContextReportCreateRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.InContextReportCreateResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class InContextReportCreateAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<InContextReportCreateRequest, InContextReportCreateResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::InContextReportCreateRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class InContextReportCreateAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: InContextReportCreateRequest): InContextReportCreateResponse {
-        return ReportInstanceActions.createOnDemand(request)
+    override fun executeRequest(request: InContextReportCreateRequest, user: User?): InContextReportCreateResponse {
+        return ReportInstanceActions.createOnDemand(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/OnDemandReportCreateAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/OnDemandReportCreateAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.OnDemandReportCreateRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.OnDemandReportCreateResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class OnDemandReportCreateAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<OnDemandReportCreateRequest, OnDemandReportCreateResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::OnDemandReportCreateRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class OnDemandReportCreateAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: OnDemandReportCreateRequest): OnDemandReportCreateResponse {
-        return ReportInstanceActions.createOnDemandFromDefinition(request)
+    override fun executeRequest(request: OnDemandReportCreateRequest, user: User?): OnDemandReportCreateResponse {
+        return ReportInstanceActions.createOnDemandFromDefinition(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/PollReportInstanceAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/PollReportInstanceAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.PollReportInstanceRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.PollReportInstanceResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class PollReportInstanceAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<PollReportInstanceRequest, PollReportInstanceResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::PollReportInstanceRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class PollReportInstanceAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: PollReportInstanceRequest): PollReportInstanceResponse {
-        return ReportInstanceActions.poll()
+    override fun executeRequest(request: PollReportInstanceRequest, user: User?): PollReportInstanceResponse {
+        return ReportInstanceActions.poll(user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/UpdateReportDefinitionAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/UpdateReportDefinitionAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.UpdateReportDefinitionRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.UpdateReportDefinitionResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class UpdateReportDefinitionAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<UpdateReportDefinitionRequest, UpdateReportDefinitionResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::UpdateReportDefinitionRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class UpdateReportDefinitionAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: UpdateReportDefinitionRequest): UpdateReportDefinitionResponse {
-        return ReportDefinitionActions.update(request)
+    override fun executeRequest(request: UpdateReportDefinitionRequest, user: User?): UpdateReportDefinitionResponse {
+        return ReportDefinitionActions.update(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/UpdateReportInstanceStatusAction.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/action/UpdateReportInstanceStatusAction.kt
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.reportsscheduler.action
 
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.UpdateReportInstanceStatusRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.UpdateReportInstanceStatusResponse
 import org.elasticsearch.action.ActionType
@@ -30,11 +31,12 @@ import org.elasticsearch.transport.TransportService
  */
 internal class UpdateReportInstanceStatusAction @Inject constructor(
     transportService: TransportService,
-    val client: Client,
+    client: Client,
     actionFilters: ActionFilters,
     val xContentRegistry: NamedXContentRegistry
 ) : PluginBaseAction<UpdateReportInstanceStatusRequest, UpdateReportInstanceStatusResponse>(NAME,
     transportService,
+    client,
     actionFilters,
     ::UpdateReportInstanceStatusRequest) {
     companion object {
@@ -45,7 +47,7 @@ internal class UpdateReportInstanceStatusAction @Inject constructor(
     /**
      * {@inheritDoc}
      */
-    override fun executeRequest(request: UpdateReportInstanceStatusRequest): UpdateReportInstanceStatusResponse {
-        return ReportInstanceActions.update(request)
+    override fun executeRequest(request: UpdateReportInstanceStatusRequest, user: User?): UpdateReportInstanceStatusResponse {
+        return ReportInstanceActions.update(request, user)
     }
 }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/index/ReportDefinitionsIndex.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/index/ReportDefinitionsIndex.kt
@@ -154,13 +154,15 @@ internal object ReportDefinitionsIndex {
      */
     fun getAllReportDefinitions(access: List<String>, from: Int, maxItems: Int): ReportDefinitionDetailsSearchResults {
         createIndex()
-        val query = QueryBuilders.termsQuery(ACCESS_LIST_FIELD, access)
         val sourceBuilder = SearchSourceBuilder()
             .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
             .sort(UPDATED_TIME_FIELD)
             .size(maxItems)
             .from(from)
-            .query(query)
+        if (access.isNotEmpty()) {
+            val query = QueryBuilders.termsQuery(ACCESS_LIST_FIELD, access)
+            sourceBuilder.query(query)
+        }
         val searchRequest = SearchRequest()
             .indices(REPORT_DEFINITIONS_INDEX_NAME)
             .source(sourceBuilder)

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/index/ReportInstancesIndex.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/index/ReportInstancesIndex.kt
@@ -158,13 +158,15 @@ internal object ReportInstancesIndex {
      */
     fun getAllReportInstances(access: List<String>, from: Int, maxItems: Int): ReportInstanceSearchResults {
         createIndex()
-        val query = QueryBuilders.termsQuery(ACCESS_LIST_FIELD, access)
         val sourceBuilder = SearchSourceBuilder()
             .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
             .sort(UPDATED_TIME_FIELD)
             .size(maxItems)
             .from(from)
-            .query(query)
+        if (access.isNotEmpty()) {
+            val query = QueryBuilders.termsQuery(ACCESS_LIST_FIELD, access)
+            sourceBuilder.query(query)
+        }
         val searchRequest = SearchRequest()
             .indices(REPORT_INSTANCES_INDEX_NAME)
             .source(sourceBuilder)

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/scheduler/ReportDefinitionJobRunner.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/scheduler/ReportDefinitionJobRunner.kt
@@ -32,7 +32,6 @@ import java.time.Instant
 internal object ReportDefinitionJobRunner : ScheduledJobRunner {
     private val log by logger(ReportDefinitionJobRunner::class.java)
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
-    private const val TEMP_ROLE_ID = "roleId" // TODO get this from request
 
     override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {
         if (job !is ReportDefinitionDetails) {
@@ -49,7 +48,7 @@ internal object ReportDefinitionJobRunner : ScheduledJobRunner {
                 currentTime,
                 beginTime,
                 endTime,
-                listOf(TEMP_ROLE_ID),
+                job.access,
                 reportDefinitionDetails,
                 ReportInstance.Status.Scheduled)
             val id = ReportInstancesIndex.createReportInstance(reportInstance)

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/security/UserAccessManager.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/security/UserAccessManager.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.reportsscheduler.security
+
+import com.amazon.opendistroforelasticsearch.commons.authuser.User
+import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings
+import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings.FilterBy
+import org.elasticsearch.ElasticsearchStatusException
+import org.elasticsearch.rest.RestStatus
+
+/**
+ * Class for checking/filtering user access.
+ */
+internal object UserAccessManager {
+    const val USER_TAG = "User:"
+    const val ROLE_TAG = "Role:"
+    const val BACKEND_ROLE_TAG = "BERole:"
+    const val ALL_ACCESS_ROLE = "all_access"
+    const val KIBANA_SERVER_USER = "kibanaserver"
+
+    /**
+     * Validate User if eligible to do operation
+     * If filterBy == NoFilter
+     *  -> No validation
+     * If filterBy == User
+     *  -> User name should be present
+     * If filterBy == BackendRoles
+     *  -> backend roles should be present
+     */
+    fun validateUser(user: User?) {
+        when (PluginSettings.filterBy) {
+            FilterBy.NoFilter -> { // No validation
+            }
+            FilterBy.User -> { // User name must be present
+                user?.name
+                    ?: throw ElasticsearchStatusException("Filter-by enabled with security disabled",
+                        RestStatus.FORBIDDEN)
+            }
+            FilterBy.BackendRoles -> { // backend roles must be present
+                if (user?.backendRoles.isNullOrEmpty()) {
+                    throw ElasticsearchStatusException("User doesn't have backend roles configured. Contact administrator.",
+                        RestStatus.FORBIDDEN)
+                }
+            }
+        }
+    }
+
+    /**
+     * validate if user has access to polling actions
+     */
+    fun validatePollingUser(user: User?): Boolean {
+        if (user == null) { // Security is disabled
+            return true
+        }
+        return (user.name == KIBANA_SERVER_USER)
+    }
+
+    /**
+     * Get all user access info from user object.
+     */
+    fun getAllAccessInfo(user: User?): List<String> {
+        if (user == null) { // Security is disabled
+            return listOf()
+        }
+        val retList: MutableList<String> = mutableListOf()
+        if (user.name != null) {
+            retList.add("$USER_TAG${user.name}")
+        }
+        user.roles.forEach { retList.add("$ROLE_TAG$it") }
+        user.backendRoles.forEach { retList.add("$BACKEND_ROLE_TAG$it") }
+        return retList
+    }
+
+    /**
+     * Get access info for search filtering
+     */
+    fun getSearchAccessInfo(user: User?): List<String> {
+        if (user == null) {
+            return listOf()
+        }
+        if (PluginSettings.adminAccess == PluginSettings.AdminAccess.AllReports && user.roles.contains(ALL_ACCESS_ROLE)) {
+            return listOf()
+        }
+        return when (PluginSettings.filterBy) {
+            FilterBy.NoFilter -> listOf()
+            FilterBy.User -> listOf("$USER_TAG${user.name}")
+            FilterBy.BackendRoles -> user.backendRoles.map { "$BACKEND_ROLE_TAG$it" }
+        }
+    }
+
+    /**
+     * validate if user has access based on given access list
+     */
+    fun doesUserHasAccess(user: User?, access: List<String>): Boolean {
+        if (user == null) {
+            return true
+        }
+        if (PluginSettings.adminAccess == PluginSettings.AdminAccess.AllReports && user.roles.contains(ALL_ACCESS_ROLE)) {
+            return true
+        }
+        return when (PluginSettings.filterBy) {
+            FilterBy.NoFilter -> true
+            FilterBy.User -> access.contains("$USER_TAG${user.name}")
+            FilterBy.BackendRoles -> user.backendRoles.map { "$BACKEND_ROLE_TAG$it" }.any { it in access }
+        }
+    }
+}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Added user and backend role based access control to APIs
Behaviour:
Default adminAccess="AllReports"
    adminAccess values:
        Standard -> Admin user access follows standard user
        AllReports -> Admin user with "all_access" role can see all reports of all users.
Default filterBy="NoFilter"
    filterBy values:
        NoFilter -> everyone see each other's reports
        User -> reports are visible to only themselves; match by username
        BackendRoles -> reports are visible to users having any one of the backend role of creator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
