### PR TITLE
Disable api calls that uses Kibana default internal user

### DIFF
--- a/kibana-reports/public/components/main/main_utils.tsx
+++ b/kibana-reports/public/components/main/main_utils.tsx
@@ -179,7 +179,7 @@ export const generateReportById = async (
   handlePermissionsMissingToast
 ) => {
   await httpClient
-    .post(`../api/reporting/generateReport/${reportId}`)
+    .get(`../api/reporting/generateReport/${reportId}`)
     .then(async (response) => {
       //TODO: duplicate code, extract to be a function that can reuse. e.g. handleResponse(response)
       const fileFormat = extractFileFormat(response['filename']);

--- a/kibana-reports/server/backend/opendistro-es-reports-plugin.ts
+++ b/kibana-reports/server/backend/opendistro-es-reports-plugin.ts
@@ -32,6 +32,20 @@ export default function (Client: any, config: any, components: any) {
     needBody: true,
   });
 
+  esReports.createReportFromDefinition = clientAction({
+    url: {
+      fmt: `${ES_REPORTS_API.ON_DEMAND_REPORT}/<%=reportDefinitionId%>`,
+      req: {
+        reportDefinitionId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'POST',
+    needBody: true,
+  });
+
   esReports.updateReportInstanceStatus = clientAction({
     url: {
       fmt: `${ES_REPORTS_API.REPORT_INSTANCE}/<%=reportInstanceId%>`,

--- a/kibana-reports/server/plugin.ts
+++ b/kibana-reports/server/plugin.ts
@@ -115,16 +115,16 @@ export class OpendistroKibanaReportsPlugin
     Polling at at a 5 min fixed interval
     
     TODO: need further optimization polling with a mix approach of
-    random delay and dynamic delay based on the amount of jobs
+    random delay and dynamic delay based on the amount of jobs. 
     */
-    setIntervalAsync(
-      pollAndExecuteJob,
-      POLL_INTERVAL,
-      esReportsClient,
-      notificationClient,
-      esClient,
-      this.logger
-    );
+    // setIntervalAsync(
+    //   pollAndExecuteJob,
+    //   POLL_INTERVAL,
+    //   esReportsClient,
+    //   notificationClient,
+    //   esClient,
+    //   this.logger
+    // );
     return {};
   }
 

--- a/kibana-reports/server/routes/lib/createReport.ts
+++ b/kibana-reports/server/routes/lib/createReport.ts
@@ -109,9 +109,10 @@ export const createReport = async (
       );
     }
     // update report state to "created"
-    if (!savedReportId) {
-      await updateReportState(reportId, esReportsClient, REPORT_STATE.created);
-    }
+    // TODO: temporarily remove the following
+    // if (!savedReportId) {
+    //   await updateReportState(reportId, esReportsClient, REPORT_STATE.created);
+    // }
 
     // deliver report
     if (!savedReportId && deliveryType == DELIVERY_TYPE.channel) {
@@ -125,10 +126,11 @@ export const createReport = async (
     }
   } catch (error) {
     // update report instance with "error" state
-    //TODO: save error detail and display on UI
-    if (!savedReportId) {
-      await updateReportState(reportId, esReportsClient, REPORT_STATE.error);
-    }
+    // TODO: save error detail and display on UI
+    // TODO: temporarily disable the following, will add back
+    // if (!savedReportId) {
+    //   await updateReportState(reportId, esReportsClient, REPORT_STATE.error);
+    // }
     throw error;
   }
 

--- a/kibana-reports/server/routes/lib/deliverReport.ts
+++ b/kibana-reports/server/routes/lib/deliverReport.ts
@@ -117,5 +117,6 @@ export const deliverReport = async (
   }
 
   // update report state
-  await updateReportState(reportId, esReportsClient, REPORT_STATE.shared);
+  // TODO: temporarily disable the following, will add back
+  // await updateReportState(reportId, esReportsClient, REPORT_STATE.shared);
 };

--- a/kibana-reports/server/routes/lib/saveReport.ts
+++ b/kibana-reports/server/routes/lib/saveReport.ts
@@ -45,7 +45,7 @@ export const saveReport = async (
         },
       },
     },
-    status: BACKEND_REPORT_STATE.executing, // download from in-context menu should always pass executing state to backend
+    status: BACKEND_REPORT_STATE.success, // download from in-context menu should always pass executing state to backend
     inContextDownloadUrlPath: queryUrl,
   };
 

--- a/kibana-reports/server/routes/lib/saveReport.ts
+++ b/kibana-reports/server/routes/lib/saveReport.ts
@@ -45,7 +45,9 @@ export const saveReport = async (
         },
       },
     },
-    status: BACKEND_REPORT_STATE.success, // download from in-context menu should always pass executing state to backend
+    // download from in-context menu should always pass executing state to backend
+    // TODO: set to success, since update report status API in temporarily unavailable, need change back to pending later
+    status: BACKEND_REPORT_STATE.success,
     inContextDownloadUrlPath: queryUrl,
   };
 

--- a/kibana-reports/server/routes/report.ts
+++ b/kibana-reports/server/routes/report.ts
@@ -32,7 +32,7 @@ import {
 } from './utils/converters/backendToUi';
 
 export default function (router: IRouter) {
-  // generate report
+  // generate report (with provided metadata)
   router.post(
     {
       path: `${API_PREFIX}/generateReport`,
@@ -85,8 +85,8 @@ export default function (router: IRouter) {
     }
   );
 
-  // generate report from id
-  router.post(
+  // generate report from report id
+  router.get(
     {
       path: `${API_PREFIX}/generateReport/{reportId}`,
       validate: {
@@ -134,6 +134,65 @@ export default function (router: IRouter) {
         });
       } catch (error) {
         logger.error(`Failed to generate report by id: ${error}`);
+        logger.error(error);
+        return errorResponse(response, error);
+      }
+    }
+  );
+
+  // create report from existing report definition
+  router.post(
+    {
+      path: `${API_PREFIX}/generateReport/{reportDefinitionId}`,
+      validate: {
+        params: schema.object({
+          reportDefinitionId: schema.string(),
+        }),
+      },
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IKibanaResponse<any | ResponseError>> => {
+      //@ts-ignore
+      const logger: Logger = context.reporting_plugin.logger;
+      const reportDefinitionId = request.params.reportDefinitionId;
+      try {
+        // @ts-ignore
+        const esReportsClient: ILegacyScopedClusterClient = context.reporting_plugin.esReportsClient.asScoped(
+          request
+        );
+        // call ES API to create report from definition
+        const esResp = await esReportsClient.callAsCurrentUser(
+          'es_reports.createReportFromDefinition',
+          {
+            reportDefinitionId: reportDefinitionId,
+            body: {
+              reportDefinitionId: reportDefinitionId,
+            },
+          }
+        );
+        // convert report to use UI model
+        const report = backendToUiReport(esResp.reportInstance);
+        // generate report
+        const reportData = await createReport(
+          request,
+          context,
+          report,
+          reportDefinitionId
+        );
+
+        return response.ok({
+          body: {
+            data: reportData.dataUrl,
+            filename: reportData.fileName,
+          },
+        });
+      } catch (error) {
+        logger.error(
+          `Failed to generate report from reportDefinition id ${reportDefinitionId} : ${error}`
+        );
         logger.error(error);
         return errorResponse(response, error);
       }

--- a/kibana-reports/server/routes/report.ts
+++ b/kibana-reports/server/routes/report.ts
@@ -173,6 +173,7 @@ export default function (router: IRouter) {
             },
           }
         );
+        const reportId = esResp.reportInstance.id;
         // convert report to use UI model
         const report = backendToUiReport(esResp.reportInstance);
         // generate report
@@ -180,7 +181,7 @@ export default function (router: IRouter) {
           request,
           context,
           report,
-          reportDefinitionId
+          reportId
         );
 
         return response.ok({


### PR DESCRIPTION
*Issue #, if available:*
We have security limitations for calling ES api with kibana default user in `kibana.yml`, which is the kibana server role. This PR removes the affected code and propose a solution.

*Description of changes:*
- disable poller, since in the backend, it has already mark every scheduled task as scueess
- add a new Kibana API `POST .../reporting/genreateReport/{reportDefinitionId}`, which calls the ES API 
```
POST .../_reports/on_demand/{reportDefinitionId}
body: {reportDefinitionId: reportDefinitionId}
```
- disable all api calls to update report status
- change `.../generateReport/{reportId}` from a `POST` request to a `GET` request, because this call will not generate resource to the server, it just generate reports on the fly without saving anything. But `.../generateReport/{reportId}` does create a new instance to the `report` index.
- TODO: UI now needs to call the above new API for the following instead of old `POST ..../generateReport` with a request body of complete parameters.
  - Generate button from report definition detail page, and the icon download as well
  - the second API call for the "create on-demand report definition" workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
