### PR TITLE
Use new API to Generate Reports from Existing Definitions

### DIFF
--- a/kibana-reports/public/components/main/__tests__/main_utils.test.tsx
+++ b/kibana-reports/public/components/main/__tests__/main_utils.test.tsx
@@ -22,7 +22,7 @@ import {
   addReportDefinitionsTableContent,
   removeDuplicatePdfFileFormat,
   readStreamToFile,
-  generateReport,
+  generateReportFromDefinitionId,
   generateReportById,
 } from '../main_utils';
 import {
@@ -114,8 +114,8 @@ describe('main_utils tests', () => {
   });
 
   test('test generateReport compile', () => {
-    const metadata = {};
-    generateReport(metadata, httpClientMock);
+    const reportDefinitionId = '1';
+    generateReportFromDefinitionId(reportDefinitionId, httpClientMock);
   });
 
   test('test generateReportById compile', () => {

--- a/kibana-reports/public/components/main/main_utils.tsx
+++ b/kibana-reports/public/components/main/main_utils.tsx
@@ -139,17 +139,16 @@ export const readStreamToFile = async (
   document.body.removeChild(link);
 };
 
-export const generateReport = async (metadata, httpClient) => {
+export const generateReportFromDefinitionId = async (reportDefinitionId, httpClient) => {
   let status = false;
   let permissionsError = false;
   await httpClient
-    .post('../api/reporting/generateReport', {
-      body: JSON.stringify(metadata),
+    .post(`../api/reporting/generateReport/${reportDefinitionId}`, {
       headers: {
         'Content-Type': 'application/json',
       },
     })
-    .then(async (response) => {
+    .then(async (response: any) => {
       // for emailing a report, this API response doesn't have response body
       if (response) {
         const fileFormat = extractFileFormat(response['filename']);

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -463,10 +463,6 @@ export function ReportDefinitionDetails(props) {
   };
 
   const generateReportFromDetails = async () => {
-    let duration =
-      reportDefinitionRawResponse.report_definition.report_params.core_params
-        .time_duration;
-    const fromDate = getRelativeStartDate(duration);
     const { httpClient } = props;
     let generateReportSuccess = await generateReportFromDefinitionId(
       reportDefinitionId,

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -37,7 +37,7 @@ import {
   formatEmails,
   trimAndRenderAsText,
 } from '../report_details/report_details';
-import { fileFormatsUpper, generateReport } from '../main_utils';
+import { fileFormatsUpper, generateReportFromDefinitionId } from '../main_utils';
 import { ReportDefinitionSchemaType } from '../../../../server/model';
 import moment from 'moment';
 import { converter } from '../../report_definitions/utils';
@@ -467,17 +467,9 @@ export function ReportDefinitionDetails(props) {
       reportDefinitionRawResponse.report_definition.report_params.core_params
         .time_duration;
     const fromDate = getRelativeStartDate(duration);
-    let onDemandDownloadMetadata = {
-      query_url: `${
-        reportDefinitionDetails.baseUrl
-      }?_g=(time:(from:'${fromDate.toISOString()}',to:'${moment().toISOString()}'))`,
-      time_from: fromDate.valueOf(),
-      time_to: moment().valueOf(),
-      report_definition: reportDefinitionRawResponse.report_definition,
-    };
     const { httpClient } = props;
-    let generateReportSuccess = await generateReport(
-      onDemandDownloadMetadata,
+    let generateReportSuccess = await generateReportFromDefinitionId(
+      reportDefinitionId,
       httpClient
     );
     if (generateReportSuccess.status) {

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -27,7 +27,7 @@ import {
 import { ReportSettings } from '../report_settings';
 import { ReportDelivery } from '../delivery';
 import { ReportTrigger } from '../report_trigger';
-import { generateReport } from '../../main/main_utils';
+import { generateReportFromDefinitionId } from '../../main/main_utils';
 import { isValidCron } from 'cron-validator';
 import { converter } from '../utils';
 import moment from 'moment';
@@ -327,15 +327,8 @@ export function CreateReport(props) {
         .then(async (resp) => {
           //TODO: consider handle the on demand report generation from server side instead
           if (metadata.trigger.trigger_type === 'On demand') {
-            let onDemandDownloadMetadata = {
-              query_url: `${
-                metadata.report_params.core_params.base_url
-              }?_g=(time:(from:'${timeRange.timeFrom.toISOString()}',to:'${timeRange.timeTo.toISOString()}'))`,
-              time_from: timeRange.timeFrom.valueOf(),
-              time_to: timeRange.timeTo.valueOf(),
-              report_definition: metadata,
-            };
-            generateReport(onDemandDownloadMetadata, httpClient);
+            const reportDefinitionId = resp.scheduler_response.reportDefinitionId;
+            generateReportFromDefinitionId(reportDefinitionId, httpClient);
           }
           window.location.assign(`opendistro_kibana_reports#/create=success`);
         })


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Refactored to call new API for generating reports from existing definitions- instead of passing in the entire metadata of creating a report, we only have to pass in the `reportDefinitionId` now. 

Usages:
* Creating a report after an on-demand report definition is created
* The `Generate report` button on the `Report definition details` page for an on-demand definition.
* The download icon under `File format` within `Report definition details`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
