### PR TITLE
Adding filtering the reports based on tenants.

### DIFF
--- a/reports-scheduler/src/main/config/reports-scheduler.yml
+++ b/reports-scheduler/src/main/config/reports-scheduler.yml
@@ -30,7 +30,7 @@ opendistro.reports:
     # adminAccess values:
     ## Standard -> Admin user access follows standard user
     ## AllReports -> Admin user with "all_access" role can see all reports of all users.
-    filterBy: "NoFilter"
+    filterBy: "NoFilter" # Applied when tenant != __user__
     # filterBy values:
     ## NoFilter -> everyone see each other's reports
     ## User -> reports are visible to only themselves

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportDefinitionDetails.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportDefinitionDetails.kt
@@ -24,7 +24,9 @@ import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.ACCE
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.CREATED_TIME_FIELD
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.ID_FIELD
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.REPORT_DEFINITION_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.TENANT_FIELD
 import com.amazon.opendistroforelasticsearch.reportsscheduler.model.RestTag.UPDATED_TIME_FIELD
+import com.amazon.opendistroforelasticsearch.reportsscheduler.security.UserAccessManager.DEFAULT_TENANT
 import com.amazon.opendistroforelasticsearch.reportsscheduler.settings.PluginSettings
 import com.amazon.opendistroforelasticsearch.reportsscheduler.util.logger
 import com.amazon.opendistroforelasticsearch.reportsscheduler.util.stringList
@@ -44,7 +46,8 @@ import java.time.Instant
  *   "id":"id",
  *   "lastUpdatedTimeMs":1603506908773,
  *   "createdTimeMs":1603506908773,
- *   "access":["u:user", "r:sample_role", "ber:sample_backend_role"]
+ *   "tenant":"__user__",
+ *   "access":["User:user", "Role:sample_role", "BERole:sample_backend_role"]
  *   "reportDefinition":{
  *      // refer [com.amazon.opendistroforelasticsearch.reportsscheduler.model.ReportDefinition]
  *   }
@@ -55,6 +58,7 @@ internal data class ReportDefinitionDetails(
     val id: String,
     val updatedTime: Instant,
     val createdTime: Instant,
+    val tenant: String,
     val access: List<String>,
     val reportDefinition: ReportDefinition
 ) : ScheduledJobParameter {
@@ -71,6 +75,7 @@ internal data class ReportDefinitionDetails(
             var id: String? = useId
             var updatedTime: Instant? = null
             var createdTime: Instant? = null
+            var tenant: String? = null
             var access: List<String> = listOf()
             var reportDefinition: ReportDefinition? = null
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser)
@@ -81,6 +86,7 @@ internal data class ReportDefinitionDetails(
                     ID_FIELD -> id = parser.text()
                     UPDATED_TIME_FIELD -> updatedTime = Instant.ofEpochMilli(parser.longValue())
                     CREATED_TIME_FIELD -> createdTime = Instant.ofEpochMilli(parser.longValue())
+                    TENANT_FIELD -> tenant = parser.text()
                     ACCESS_LIST_FIELD -> access = parser.stringList()
                     REPORT_DEFINITION_FIELD -> reportDefinition = ReportDefinition.parse(parser)
                     else -> {
@@ -92,10 +98,12 @@ internal data class ReportDefinitionDetails(
             id ?: throw IllegalArgumentException("$ID_FIELD field absent")
             updatedTime ?: throw IllegalArgumentException("$UPDATED_TIME_FIELD field absent")
             createdTime ?: throw IllegalArgumentException("$CREATED_TIME_FIELD field absent")
+            tenant = tenant ?: DEFAULT_TENANT
             reportDefinition ?: throw IllegalArgumentException("$REPORT_DEFINITION_FIELD field absent")
             return ReportDefinitionDetails(id,
                 updatedTime,
                 createdTime,
+                tenant,
                 access,
                 reportDefinition)
         }
@@ -121,6 +129,7 @@ internal data class ReportDefinitionDetails(
         }
         builder.field(UPDATED_TIME_FIELD, updatedTime.toEpochMilli())
             .field(CREATED_TIME_FIELD, createdTime.toEpochMilli())
+            .field(TENANT_FIELD, tenant)
         if (params?.paramAsBoolean(ACCESS_LIST_FIELD, true) == true && access.isNotEmpty()) {
             builder.field(ACCESS_LIST_FIELD, access)
         }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/RestTag.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/RestTag.kt
@@ -27,6 +27,7 @@ internal object RestTag {
     const val STATUS_TEXT_FIELD = "statusText"
     const val UPDATED_TIME_FIELD = "lastUpdatedTimeMs"
     const val CREATED_TIME_FIELD = "createdTimeMs"
+    const val TENANT_FIELD = "tenant"
     const val ACCESS_LIST_FIELD = "access"
     const val REPORT_DEFINITION_LIST_FIELD = "reportDefinitionDetailsList"
     const val REPORT_INSTANCE_LIST_FIELD = "reportInstanceList"

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/scheduler/ReportDefinitionJobRunner.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/scheduler/ReportDefinitionJobRunner.kt
@@ -48,6 +48,7 @@ internal object ReportDefinitionJobRunner : ScheduledJobRunner {
                 currentTime,
                 beginTime,
                 endTime,
+                job.tenant,
                 job.access,
                 reportDefinitionDetails,
                 ReportInstance.Status.Success) // TODO: Revert to Scheduled when background job execution supported

--- a/reports-scheduler/src/main/resources/report-definitions-mapping.yml
+++ b/reports-scheduler/src/main/resources/report-definitions-mapping.yml
@@ -27,6 +27,8 @@ properties:
   createdTimeMs:
     type: date
     format: epoch_millis
+  tenant:
+    type: keyword
   access: # Array of access details like user,role,backend_role etc
     type: keyword
   reportDefinition:

--- a/reports-scheduler/src/main/resources/report-instances-mapping.yml
+++ b/reports-scheduler/src/main/resources/report-instances-mapping.yml
@@ -27,6 +27,8 @@ properties:
   createdTimeMs:
     type: date
     format: epoch_millis
+  tenant:
+    type: keyword
   access: # Array of access details like user,role,backend_role etc
     type: keyword
   status:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding filtering the reports based on tenants.

When user=null or tenant=null, tenant is considered ""
The APIs match for tenant info from user context


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
