### PR TITLE
Add Icon to Refresh Button on Landing Page

### DIFF
--- a/kibana-reports/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
+++ b/kibana-reports/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
@@ -35,6 +35,16 @@ exports[`<Main /> panel render component 1`] = `
           <span
             class="euiButtonContent euiButton__content"
           >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
             <span
               class="euiButton__text"
             >
@@ -482,6 +492,16 @@ exports[`<Main /> panel render component 1`] = `
           <span
             class="euiButtonContent euiButton__content"
           >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            />
             <span
               class="euiButton__text"
             >
@@ -900,6 +920,20 @@ exports[`<Main /> panel render component after create success 1`] = `
           <span
             class="euiButtonContent euiButton__content"
           >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.228 2.942a.5.5 0 11-.538.842A5 5 0 1013 8a.5.5 0 111 0 6 6 0 11-2.772-5.058zM14 1.5v3A1.5 1.5 0 0112.5 6h-3a.5.5 0 010-1h3a.5.5 0 00.5-.5v-3a.5.5 0 111 0z"
+              />
+            </svg>
             <span
               class="euiButton__text"
             >
@@ -1370,6 +1404,20 @@ exports[`<Main /> panel render component after create success 1`] = `
           <span
             class="euiButtonContent euiButton__content"
           >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.228 2.942a.5.5 0 11-.538.842A5 5 0 1013 8a.5.5 0 111 0 6 6 0 11-2.772-5.058zM14 1.5v3A1.5 1.5 0 0112.5 6h-3a.5.5 0 010-1h3a.5.5 0 00.5-.5v-3a.5.5 0 111 0z"
+              />
+            </svg>
             <span
               class="euiButton__text"
             >
@@ -1850,6 +1898,20 @@ exports[`<Main /> panel render component after edit success 1`] = `
           <span
             class="euiButtonContent euiButton__content"
           >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.228 2.942a.5.5 0 11-.538.842A5 5 0 1013 8a.5.5 0 111 0 6 6 0 11-2.772-5.058zM14 1.5v3A1.5 1.5 0 0112.5 6h-3a.5.5 0 010-1h3a.5.5 0 00.5-.5v-3a.5.5 0 111 0z"
+              />
+            </svg>
             <span
               class="euiButton__text"
             >
@@ -2320,6 +2382,20 @@ exports[`<Main /> panel render component after edit success 1`] = `
           <span
             class="euiButtonContent euiButton__content"
           >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.228 2.942a.5.5 0 11-.538.842A5 5 0 1013 8a.5.5 0 111 0 6 6 0 11-2.772-5.058zM14 1.5v3A1.5 1.5 0 0112.5 6h-3a.5.5 0 010-1h3a.5.5 0 00.5-.5v-3a.5.5 0 111 0z"
+              />
+            </svg>
             <span
               class="euiButton__text"
             >

--- a/kibana-reports/public/components/main/main.tsx
+++ b/kibana-reports/public/components/main/main.tsx
@@ -246,7 +246,11 @@ export function Main(props) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem component="span" grow={false}>
-            <EuiButton size="m" onClick={refreshReportsTable}>
+            <EuiButton 
+              onClick={refreshReportsTable} 
+              iconSide='left' 
+              iconType='refresh'
+            >
               Refresh
             </EuiButton>
           </EuiFlexItem>
@@ -276,7 +280,11 @@ export function Main(props) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton onClick={refreshReportsDefinitionsTable}>
+            <EuiButton 
+              onClick={refreshReportsDefinitionsTable} 
+              iconSide='left' 
+              iconType='refresh'
+            >
               Refresh
             </EuiButton>
           </EuiFlexItem>


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Adds the `refresh` icon to the Refresh buttons on the Landing page. Updated relevant snapshots. 

![Screen Shot 2020-11-24 at 4 57 26 PM](https://user-images.githubusercontent.com/53581635/100168797-ce793280-2e76-11eb-989d-ac8b6a76f06b.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
