### PR TITLE
position change for reporting plugin in side bar

### DIFF
--- a/kibana-reports/public/plugin.ts
+++ b/kibana-reports/public/plugin.ts
@@ -39,8 +39,13 @@ export class OpendistroKibanaReportsPlugin
     core.application.register({
       id: PLUGIN_NAME,
       title: 'Reporting',
-      category: DEFAULT_APP_CATEGORIES.kibana,
-      order: 8037,
+      category: {
+        id: 'odfe',
+        label: 'Open Distro for Elasticsearch',
+        euiIconType: 'logoKibana',
+        order: 2000,
+      },
+      order: 2000,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change position of reporting plugin in side bar. 
The order is designed by UX designer and in step of 1000(https://github.com/elastic/kibana/blob/master/docs/development/core/public/kibana-plugin-core-public.appcategory.md). 
The sql workbench is the second in the row. So I put 2000 for the order number. 
![image (4)](https://user-images.githubusercontent.com/53279298/100165385-03818700-2e6f-11eb-9061-2e95ece2f5d1.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
