### PR TITLE
Add Multiselect for Reports Table

### DIFF
--- a/kibana-reports/public/components/main/reports_table.tsx
+++ b/kibana-reports/public/components/main/reports_table.tsx
@@ -232,7 +232,7 @@ export function ReportsTable(props) {
         type: 'field_value_selection',
         field: 'type',
         name: 'Type',
-        multiselect: false,
+        multiSelect: 'or',
         options: reportTypeOptions.map((type) => ({
           value: type,
           name: type,
@@ -243,7 +243,7 @@ export function ReportsTable(props) {
         type: 'field_value_selection',
         field: 'state',
         name: 'State',
-        multiselect: false,
+        multiSelect: 'or',
         options: reportStatusOptions.map((state) => ({
           value: state,
           name: state,


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Users can now select multiple filters correctly with `or` logic instead of `and`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
