### PR TITLE
Added Loading Modal to Details pages

### DIFF
--- a/kibana-reports/public/components/main/loading_modal/index.ts
+++ b/kibana-reports/public/components/main/loading_modal/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+ export { GenerateReportLoadingModal } from './loading_modal';

--- a/kibana-reports/public/components/main/loading_modal/loading_modal.tsx
+++ b/kibana-reports/public/components/main/loading_modal/loading_modal.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { 
+  EuiOverlayMask, 
+  EuiModal, 
+  EuiModalHeader, 
+  EuiTitle, 
+  EuiText, 
+  EuiModalBody, 
+  EuiSpacer, 
+  EuiFlexGroup, 
+  EuiFlexItem, 
+  EuiLoadingSpinner, 
+  EuiButton 
+} from "@elastic/eui";
+import React, { useState } from "react";
+
+export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
+  const {
+    setShowLoading
+  } = props;
+  
+  const [isModalVisible, setIsModalVisible] = useState(true);
+
+  const closeModal = () => {
+    setIsModalVisible(false);
+    setShowLoading(false);
+  };
+  const showModal = () => setIsModalVisible(true);
+
+  return (
+    <div>
+      <EuiOverlayMask>
+        <EuiModal
+          onClose={closeModal}
+          style={{ maxWidth: 350, minWidth: 300 }}
+        >
+          <EuiModalHeader>
+            <EuiTitle>
+              <EuiText textAlign="right">
+                <h2>Generating report</h2>
+              </EuiText>
+            </EuiTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <EuiText>Preparing your file for download.</EuiText>
+            <EuiText>
+              You can close this dialog while we continue in the background.
+            </EuiText>
+            <EuiSpacer />
+            <EuiFlexGroup justifyContent="center" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner
+                  size="xl"
+                  style={{ minWidth: 75, minHeight: 75 }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="l" />
+            <EuiFlexGroup alignItems="flexEnd" justifyContent="flexEnd">
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={closeModal}>Close</EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiModalBody>
+        </EuiModal>
+      </EuiOverlayMask>
+    </div>
+  );
+};

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -45,6 +45,7 @@ import {
   permissionsMissingToast,
   permissionsMissingActions,
 } from '../../utils/utils';
+import { GenerateReportLoadingModal } from '../loading_modal';
 
 const ON_DEMAND = 'On demand';
 
@@ -56,7 +57,12 @@ export function ReportDefinitionDetails(props) {
   ] = useState({});
   const [toasts, setToasts] = useState([]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showLoading, setShowLoading] = useState(false);
   const reportDefinitionId = props.match['params']['reportDefinitionId'];
+
+  const handleLoading = (e) => {
+    setShowLoading(e);
+  }
 
   const handleShowDeleteModal = (e) => {
     setShowDeleteModal(e);
@@ -380,11 +386,17 @@ export function ReportDefinitionDetails(props) {
       });
   }, []);
 
+  const downloadIconDownload = async () => {
+    handleLoading(true);
+    await generateReportFromDetails();
+    handleLoading(false);
+  }
+
   const fileFormatDownload = (data) => {
     let formatUpper = data['fileFormat'];
     formatUpper = fileFormatsUpper[formatUpper];
     return (
-      <EuiLink onClick={generateReportFromDetails}>
+      <EuiLink onClick={downloadIconDownload}>
         {formatUpper + ' '}
         <EuiIcon type="importAction" />
       </EuiLink>
@@ -538,6 +550,9 @@ export function ReportDefinitionDetails(props) {
     <DeleteConfirmationModal />
   ) : null;
 
+  const showLoadingModal = showLoading ?
+    <GenerateReportLoadingModal setShowLoading={setShowLoading} /> : null;
+
   return (
     <EuiPage>
       <EuiPageBody>
@@ -687,6 +702,7 @@ export function ReportDefinitionDetails(props) {
           toastLifeTimeMs={6000}
         />
         {showDeleteConfirmationModal}
+        {showLoadingModal}
       </EuiPageBody>
     </EuiPage>
   );

--- a/kibana-reports/public/components/main/reports_table.tsx
+++ b/kibana-reports/public/components/main/reports_table.tsx
@@ -22,21 +22,13 @@ import {
   EuiIcon,
   EuiEmptyPrompt,
   EuiInMemoryTable,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLoadingSpinner,
-  EuiModal,
-  EuiModalBody,
-  EuiModalHeader,
-  EuiOverlayMask,
-  EuiSpacer,
-  EuiTitle,
 } from '@elastic/eui';
 import {
   fileFormatsUpper,
   humanReadableDate,
   generateReportById,
 } from './main_utils';
+import { GenerateReportLoadingModal } from './loading_modal';
 
 const reportStatusOptions = [
   'Created',
@@ -85,56 +77,6 @@ export function ReportsTable(props) {
 
   const handleLoading = (e) => {
     setShowLoading(e);
-  };
-
-  const GenerateReportLoadingModal = () => {
-    const [isModalVisible, setIsModalVisible] = useState(true);
-
-    const closeModal = () => {
-      setIsModalVisible(false);
-      setShowLoading(false);
-    };
-    const showModal = () => setIsModalVisible(true);
-
-    return (
-      <div>
-        <EuiOverlayMask>
-          <EuiModal
-            onClose={closeModal}
-            style={{ maxWidth: 350, minWidth: 300 }}
-          >
-            <EuiModalHeader>
-              <EuiTitle>
-                <EuiText textAlign="right">
-                  <h2>Generating report</h2>
-                </EuiText>
-              </EuiTitle>
-            </EuiModalHeader>
-            <EuiModalBody>
-              <EuiText>Preparing your file for download.</EuiText>
-              <EuiText>
-                You can close this dialog while we continue in the background.
-              </EuiText>
-              <EuiSpacer />
-              <EuiFlexGroup justifyContent="center" alignItems="center">
-                <EuiFlexItem grow={false}>
-                  <EuiLoadingSpinner
-                    size="xl"
-                    style={{ minWidth: 75, minHeight: 75 }}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiSpacer size="l" />
-              <EuiFlexGroup alignItems="flexEnd" justifyContent="flexEnd">
-                <EuiFlexItem grow={false}>
-                  <EuiButton onClick={closeModal}>Close</EuiButton>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiModalBody>
-          </EuiModal>
-        </EuiOverlayMask>
-      </div>
-    );
   };
 
   const onDemandDownload = async (id: any) => {
@@ -258,7 +200,8 @@ export function ReportsTable(props) {
       ? emptyMessageReports
       : '0 reports match the search criteria. Search again';
 
-  const showLoadingModal = showLoading ? <GenerateReportLoadingModal /> : null;
+  const showLoadingModal = showLoading ? 
+    <GenerateReportLoadingModal setShowLoading={setShowLoading} /> : null;
 
   return (
     <Fragment>


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Extract `GenerateReportLoadingModal` and added it to `Report details` and `Report definition details` for file format download. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
