### PR TITLE
Use puppeteer-core with custom chromium instead of puppeteer

### DIFF
--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -57,8 +57,25 @@ jobs:
         run: |
           cd kibana/plugins/kibana-reports
           yarn build
-          mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
-          artifact=`ls ./build/*.zip`
+
+          cd build
+          mkdir -p ./{linux,windows}/kibana/opendistroReportsKibana
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+
+          cd linux
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
+          unzip chromium-linux.zip -d ./kibana/opendistroReportsKibana
+          zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ..
+          cd ..
+
+          cd windows
+          # TODO add chromium windows binary
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ..
+          cd ..
+
+          artifact=`ls ./${{ env.PLUGIN_NAME }}-*.zip`
 
           # TODO: rename S3 bucket path after infra team assigns one
           aws s3 cp $artifact s3://kiabna-reports/kibana-reports-plugin/

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -37,25 +37,25 @@ jobs:
           node-version: "10.22.1"
 
       - name: Move Kibana Reports to Plugins Dir
-        run: mv kibana-reports kibana/plugins
+        run: mv kibana-reports kibana/plugins/opendistroReportsKibana
 
       - name: Kibana Plugin Bootstrap
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/kibana-reports; yarn kbn bootstrap
+          command: cd kibana/plugins/opendistroReportsKibana; yarn kbn bootstrap
 
       - name: Test
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/kibana-reports; yarn test
+          command: cd kibana/plugins/opendistroReportsKibana; yarn test
 
       - name: Build Artifact
         run: |
-          cd kibana/plugins/kibana-reports
+          cd kibana/plugins/opendistroReportsKibana
           yarn build
 
           cd build
@@ -79,6 +79,5 @@ jobs:
 
           artifact=`ls ./${{ env.PLUGIN_NAME }}-*.zip`
 
-          # TODO: rename S3 bucket path after infra team assigns one
-          aws s3 cp $artifact s3://kiabna-reports/kibana-reports-plugin/
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -71,7 +71,9 @@ jobs:
           cd ..
 
           cd windows
-          # TODO add chromium windows binary
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows.zip
+          unzip chromium-windows.zip -d ./kibana/opendistroReportsKibana
+          zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -46,10 +46,23 @@ jobs:
         run: |
           cd kibana/plugins/kibana-reports
           yarn build
-          mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
+          cd build
+          mkdir -p ./{ubuntu,centos,al2,windows}/kibana/opendistroKibanaReports
+          cp ./${{ env.PLUGIN_NAME }}.zip ./ubuntu/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-ubuntu-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}.zip ./centos/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-centos-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}.zip ./al2/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-al2-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          cd al2
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-al2.zip
+          unzip chromium-al2.zip -d ./kibana/opendistroKibanaReports
+          zip -r ./${{ env.PLUGIN_NAME }}.zip ./kibana
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:
           name: kibana-reports
-          path: kibana/plugins/kibana-reports/build
+          path: |
+            kibana/plugins/kibana-reports/build/ubuntu
+            kibana/plugins/kibana-reports/build/al2
+            kibana/plugins/kibana-reports/build/centos
+            kibana/plugins/kibana-reports/build/windows

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -46,23 +46,32 @@ jobs:
         run: |
           cd kibana/plugins/kibana-reports
           yarn build
-          cd build
-          mkdir -p ./{ubuntu,centos,al2,windows}/kibana/opendistroReportsKibana
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./ubuntu/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-ubuntu-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./centos/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-centos-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./al2/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-al2-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
-          cd al2
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-al2.zip
-          unzip chromium-al2.zip -d ./kibana/opendistroReportsKibana
-          zip -r ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
 
-      - name: Upload Artifact
+          cd build
+          mkdir -p ./{linux,windows}/kibana/opendistroReportsKibana
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+
+          cd linux
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
+          unzip chromium-linux.zip -d ./kibana/opendistroReportsKibana
+          zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ..
+          cd ..
+
+          cd windows
+          # TODO add chromium windows binary
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ..
+          cd ..
+
+      - name: Upload Artifact For Linux
         uses: actions/upload-artifact@v1
         with:
-          name: kibana-reports
-          path: |
-            kibana/plugins/kibana-reports/build/ubuntu
-            kibana/plugins/kibana-reports/build/al2
-            kibana/plugins/kibana-reports/build/centos
-            kibana/plugins/kibana-reports/build/windows
+          name: kibana-reports-linux
+          path: kibana/plugins/kibana-reports/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+
+      - name: Upload Artifact For Windows
+        uses: actions/upload-artifact@v1
+        with:
+          name: kibana-reports-windows
+          path: kibana/plugins/kibana-reports/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -47,14 +47,14 @@ jobs:
           cd kibana/plugins/kibana-reports
           yarn build
           cd build
-          mkdir -p ./{ubuntu,centos,al2,windows}/kibana/opendistroKibanaReports
-          cp ./opendistro*-*.zip ./ubuntu/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-ubuntu-x64.zip
-          cp ./opendistro*-*.zip ./centos/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-centos-x64.zip
-          cp ./opendistro*-*.zip ./al2/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-al2-x64.zip
-          cp ./opendistro*-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          mkdir -p ./{ubuntu,centos,al2,windows}/kibana/opendistroReportsKibana
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./ubuntu/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-ubuntu-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./centos/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-centos-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./al2/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-al2-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
           cd al2
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-al2.zip
-          unzip chromium-al2.zip -d ./kibana/opendistroKibanaReports
+          unzip chromium-al2.zip -d ./kibana/opendistroReportsKibana
           zip -r ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
 
       - name: Upload Artifact

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -43,12 +43,12 @@ jobs:
           max_attempts: 3
           command: cd kibana/plugins/kibana-reports; yarn kbn bootstrap
 
-      - name: Test
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: cd kibana/plugins/kibana-reports; yarn test
+      # - name: Test
+      #   uses: nick-invision/retry@v1
+      #   with:
+      #     timeout_minutes: 30
+      #     max_attempts: 3
+      #     command: cd kibana/plugins/kibana-reports; yarn test
 
       - name: Build Artifact
         run: |
@@ -68,7 +68,9 @@ jobs:
           cd ..
 
           cd windows
-          # TODO add chromium windows binary
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows.zip
+          unzip chromium-windows.zip -d ./kibana/opendistroReportsKibana
+          zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Move Kibana Reports to Plugins Dir
         run: mv kibana-reports kibana/plugins
 
+      - name: Add Chromium Binary to Reporting for Testing
+        run: |
+          sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
+          cd kibana/plugins/kibana-reports
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
+          unzip chromium-linux.zip
+          rm chromium-linux.zip
+
       - name: Kibana Plugin Bootstrap
         uses: nick-invision/retry@v1
         with:
@@ -35,12 +43,12 @@ jobs:
           max_attempts: 3
           command: cd kibana/plugins/kibana-reports; yarn kbn bootstrap
 
-      # - name: Test
-      #   uses: nick-invision/retry@v1
-      #   with:
-      #     timeout_minutes: 30
-      #     max_attempts: 3
-      #     command: cd kibana/plugins/kibana-reports; yarn test
+      - name: Test
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: cd kibana/plugins/kibana-reports; yarn test
 
       - name: Build Artifact
         run: |

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -35,12 +35,12 @@ jobs:
           max_attempts: 3
           command: cd kibana/plugins/kibana-reports; yarn kbn bootstrap
 
-      - name: Test
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: cd kibana/plugins/kibana-reports; yarn test
+      # - name: Test
+      #   uses: nick-invision/retry@v1
+      #   with:
+      #     timeout_minutes: 30
+      #     max_attempts: 3
+      #     command: cd kibana/plugins/kibana-reports; yarn test
 
       - name: Build Artifact
         run: |

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -48,14 +48,14 @@ jobs:
           yarn build
           cd build
           mkdir -p ./{ubuntu,centos,al2,windows}/kibana/opendistroKibanaReports
-          cp ./${{ env.PLUGIN_NAME }}.zip ./ubuntu/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-ubuntu-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}.zip ./centos/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-centos-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}.zip ./al2/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-al2-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          cp ./opendistro*-*.zip ./ubuntu/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-ubuntu-x64.zip
+          cp ./opendistro*-*.zip ./centos/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-centos-x64.zip
+          cp ./opendistro*-*.zip ./al2/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-al2-x64.zip
+          cp ./opendistro*-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
           cd al2
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-al2.zip
           unzip chromium-al2.zip -d ./kibana/opendistroKibanaReports
-          zip -r ./${{ env.PLUGIN_NAME }}.zip ./kibana
+          zip -r ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -26,12 +26,12 @@ jobs:
           node-version: "10.22.1"
 
       - name: Move Kibana Reports to Plugins Dir
-        run: mv kibana-reports kibana/plugins
+        run: mv kibana-reports kibana/plugins/opendistroReportsKibana
 
       - name: Add Chromium Binary to Reporting for Testing
         run: |
           sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
-          cd kibana/plugins/kibana-reports
+          cd kibana/plugins/opendistroReportsKibana
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
           unzip chromium-linux.zip
           rm chromium-linux.zip
@@ -41,18 +41,18 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/kibana-reports; yarn kbn bootstrap
+          command: cd kibana/plugins/opendistroReportsKibana; yarn kbn bootstrap
 
-      # - name: Test
-      #   uses: nick-invision/retry@v1
-      #   with:
-      #     timeout_minutes: 30
-      #     max_attempts: 3
-      #     command: cd kibana/plugins/kibana-reports; yarn test
+      - name: Test
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: cd kibana/plugins/opendistroReportsKibana; yarn test
 
       - name: Build Artifact
         run: |
-          cd kibana/plugins/kibana-reports
+          cd kibana/plugins/opendistroReportsKibana
           yarn build
 
           cd build
@@ -78,10 +78,10 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: kibana-reports-linux
-          path: kibana/plugins/kibana-reports/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
 
       - name: Upload Artifact For Windows
         uses: actions/upload-artifact@v1
         with:
           name: kibana-reports-windows
-          path: kibana/plugins/kibana-reports/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip

--- a/kibana-reports/common/index.ts
+++ b/kibana-reports/common/index.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-export const PLUGIN_ID = 'opendistroKibanaReports';
+export const PLUGIN_ID = 'opendistroReportsKibana';
 export const PLUGIN_NAME = 'opendistro_kibana_reports';
 
 export const API_PREFIX = '/api/reporting';

--- a/kibana-reports/kibana.json
+++ b/kibana-reports/kibana.json
@@ -1,5 +1,5 @@
 {
-  "id": "opendistroKibanaReports",
+  "id": "opendistroReportsKibana",
   "version": "1.12.0.0",
   "kibanaVersion": "7.10.0",
   "requiredPlugins": ["navigation", "data"],

--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -20,12 +20,12 @@
     "plugin_helpers": "node ../../scripts/plugin_helpers"
   },
   "dependencies": {
-    "enzyme-adapter-react-16": "^1.15.2",
     "babel-polyfill": "^6.26.0",
     "cheerio": "0.22.0",
     "cron-validator": "^1.1.1",
     "dompurify": "^2.1.1",
     "elastic-builder": "^2.7.1",
+    "enzyme-adapter-react-16": "^1.15.2",
     "jest-fetch-mock": "^3.0.3",
     "jquery": "^3.5.0",
     "jsdom": "13.1.0",
@@ -46,15 +46,16 @@
   "devDependencies": {
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/kbn-eslint-import-resolver-kibana",
     "@types/dompurify": "^2.0.4",
-    "@types/jsdom": "^16.2.3",
-    "@types/react-addons-test-utils": "^0.14.25",
     "@types/enzyme-adapter-react-16": "^1.0.6",
-    "@types/puppeteer": "^1.20.1",
+    "@types/jsdom": "^16.2.3",
+    "@types/puppeteer-core": "^2.0.0",
     "@types/react": "^16.9.36",
+    "@types/react-addons-test-utils": "^0.14.25",
     "@types/react-dom": "^16.9.8",
     "@types/react-test-renderer": "^16.9.1",
     "@types/set-interval-async": "^1.0.0",
     "@types/showdown": "^1.9.3",
+    "babel-jest": "^26.3.0",
     "elastic-builder": "^2.7.1",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-no-unsanitized": "^3.0.2",
@@ -63,7 +64,6 @@
     "jest-dom": "^4.0.0",
     "react-test-renderer": "^16.12.0",
     "ts-jest": "^26.1.0",
-    "tsc": "^1.20150623.0",
-    "babel-jest": "^26.3.0"
+    "tsc": "^1.20150623.0"
   }
 }

--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -30,7 +30,6 @@
     "jquery": "^3.5.0",
     "jsdom": "13.1.0",
     "json-2-csv": "^3.7.6",
-    "puppeteer": "^5.3.1",
     "react-addons-test-utils": "^15.6.2",
     "react-id-generator": "^3.0.1",
     "react-markdown": "^4.3.1",

--- a/kibana-reports/server/routes/lib/createReport.ts
+++ b/kibana-reports/server/routes/lib/createReport.ts
@@ -31,7 +31,7 @@ import { createSavedSearchReport } from '../utils/savedSearchReportHelper';
 import { ReportSchemaType } from '../../model';
 import { CreateReportResultType } from '../utils/types';
 import { createVisualReport } from '../utils/visual_report/visualReportHelper';
-import { SetCookie } from 'puppeteer';
+import { SetCookie } from 'puppeteer-core';
 import { deliverReport } from './deliverReport';
 import { updateReportState } from './updateReportState';
 import { saveReport } from './saveReport';

--- a/kibana-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
+++ b/kibana-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
@@ -74,7 +74,9 @@ describe('test create visual report', () => {
     const { dataUrl, fileName } = await createVisualReport(
       reportParams as ReportParamsSchemaType,
       queryUrl,
-      mockLogger
+      mockLogger,
+      undefined,
+      './.chromium/headless_shell'
     );
     expect(fileName).toContain(`${reportParams.report_name}`);
     expect(fileName).toContain('.png');
@@ -89,7 +91,9 @@ describe('test create visual report', () => {
     const { dataUrl, fileName } = await createVisualReport(
       reportParams as ReportParamsSchemaType,
       queryUrl,
-      mockLogger
+      mockLogger,
+      undefined,
+      './.chromium/headless_shell'
     );
     expect(fileName).toContain(`${reportParams.report_name}`);
     expect(fileName).toContain('.pdf');

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -77,3 +77,6 @@ export const LOCAL_HOST = 'http://localhost:5601';
 export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 
 export const SECURITY_AUTH_COOKIE_NAME = 'security_authentication';
+
+export const CHROMIUM_PATH =
+  './plugins/opendistroReportsKibana/.chromium/headless_shell';

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -22,6 +22,7 @@ import {
   REPORT_TYPE,
   FORMAT,
   SELECTOR,
+  CHROMIUM_PATH,
 } from '../constants';
 import { getFileName } from '../helpers';
 import { CreateReportResultType } from '../types';
@@ -33,7 +34,8 @@ export const createVisualReport = async (
   reportParams: ReportParamsSchemaType,
   queryUrl: string,
   logger: Logger,
-  cookie?: SetCookie
+  cookie?: SetCookie,
+  chromiumPath = CHROMIUM_PATH
 ): Promise<CreateReportResultType> => {
   const {
     core_params,
@@ -66,7 +68,7 @@ export const createVisualReport = async (
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    executablePath: './plugins/kibana-reports/.chromium/headless_shell',
+    executablePath: chromiumPath,
   });
   const page = await browser.newPage();
   page.setDefaultNavigationTimeout(0);

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -66,7 +66,7 @@ export const createVisualReport = async (
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    executablePath: './plugins/kibana-reports/linux_x86/headless_shell',
+    executablePath: './plugins/kibana-reports/.chromium/headless_shell',
   });
   const page = await browser.newPage();
   page.setDefaultNavigationTimeout(0);

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import puppeteer, { ElementHandle, SetCookie } from 'puppeteer';
+import puppeteer, { ElementHandle, SetCookie } from 'puppeteer-core';
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
 import { Logger } from '../../../../../../src/core/server';
@@ -66,6 +66,7 @@ export const createVisualReport = async (
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    executablePath: './plugins/kibana-reports/linux_x86/headless_shell',
   });
   const page = await browser.newPage();
   page.setDefaultNavigationTimeout(0);

--- a/kibana-reports/server/utils/validationHelper.ts
+++ b/kibana-reports/server/utils/validationHelper.ts
@@ -16,7 +16,7 @@
 import path from 'path';
 
 export const isValidRelativeUrl = (relativeUrl: string) => {
-  const normalizedRelativeUrl = path.normalize(relativeUrl);
+  const normalizedRelativeUrl = path.posix.normalize(relativeUrl);
   // check pattern
   // ODFE pattern: /app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g
   // AES pattern: /_plugin/kibana/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g

--- a/kibana-reports/yarn.lock
+++ b/kibana-reports/yarn.lock
@@ -610,10 +610,17 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/puppeteer@^1.20.1":
-  version "1.20.7"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-1.20.7.tgz#31fb4274f0c6ec2e90ed8473616243f15a808017"
-  integrity sha512-LCfP/Zf/y4I/hG8ARR8htPYa1wpLpUkysJo9TffmQssVz8c1b9uDNU4benDHSldiz7HVAMek1DCWz7KbqEUg3w==
+"@types/puppeteer-core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer-core/-/puppeteer-core-2.0.0.tgz#3b7fbbac53d56b566f5ef096116e1d60d504aa45"
+  integrity sha512-JvoEb7KgEkUet009ZDrtpUER3hheXoHgQByuYpJZ5WWT7LWwMH+0NTqGQXGgoOKzs+G5NA1T4DZwXK79Bhnejw==
+  dependencies:
+    "@types/puppeteer" "*"
+
+"@types/puppeteer@*":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.0.tgz#1ef860bd7a9dcf0c4633aac8c0ec21f75b431868"
+  integrity sha512-zTYDLjnHjgzokrwKt7N0rgn7oZPYo1J0m8Ghu+gXqzLCEn8RWbELa2uprE2UFJ0jU/Sk0x9jXXdOH/5QQLFHhQ==
   dependencies:
     "@types/node" "*"
 

--- a/kibana-reports/yarn.lock
+++ b/kibana-reports/yarn.lock
@@ -678,13 +678,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yauzl@^2.9.1":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
-  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
-  dependencies:
-    "@types/node" "*"
-
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -862,11 +855,6 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
-
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 airbnb-prop-types@^2.16.0:
   version "2.16.0"
@@ -1224,15 +1212,6 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
-  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
-  dependencies:
-    buffer "^5.5.0"
-    inherits "^2.0.4"
-    readable-stream "^3.4.0"
-
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -1369,11 +1348,6 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1392,14 +1366,6 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-buffer@^5.2.1, buffer@^5.5.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
-  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -1879,19 +1845,19 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
 debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1954,11 +1920,6 @@ des.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
-
-devtools-protocol@0.0.818844:
-  version "0.0.818844"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.818844.tgz#d1947278ec85b53e4c8ca598f607a28fa785ba9e"
-  integrity sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -2139,7 +2100,7 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -2460,17 +2421,6 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
-  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
-  dependencies:
-    debug "^4.1.1"
-    get-stream "^5.1.0"
-    yauzl "^2.10.0"
-  optionalDependencies:
-    "@types/yauzl" "^2.9.1"
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -2502,13 +2452,6 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
-  dependencies:
-    pend "~1.2.0"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -2558,7 +2501,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.0.0, find-up@^4.1.0:
+find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -2607,11 +2550,6 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -2693,13 +2631,6 @@ get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
-
-get-stream@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -2933,14 +2864,6 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
-
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
-  dependencies:
-    agent-base "5"
-    debug "4"
 
 i18n-js@3.0.11:
   version "3.0.11"
@@ -3900,11 +3823,6 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp-classic@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
-
 mkdirp@1.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -3971,7 +3889,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@2.6.1, node-fetch@^2.6.1:
+node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -4323,11 +4241,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4356,13 +4269,6 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
-
-pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -4399,11 +4305,6 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -4431,11 +4332,6 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
-
-proxy-from-env@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -4503,24 +4399,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-puppeteer@^5.3.1:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.5.0.tgz#331a7edd212ca06b4a556156435f58cbae08af00"
-  integrity sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==
-  dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.818844"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    node-fetch "^2.6.1"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -4697,7 +4575,7 @@ react-transition-group@^4.3.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -4887,13 +4765,6 @@ rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -5323,27 +5194,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar-fs@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.0.tgz#d1cdd121ab465ee0eb9ccde2d35049d3f3daf0d5"
-  integrity sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==
-  dependencies:
-    chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
-    pump "^3.0.0"
-    tar-stream "^2.0.0"
-
-tar-stream@^2.0.0:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.4.tgz#c4fb1a11eb0da29b893a5b25476397ba2d053bfa"
-  integrity sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==
-  dependencies:
-    bl "^4.0.3"
-    end-of-stream "^1.4.1"
-    fs-constants "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.1.1"
-
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
@@ -5384,11 +5234,6 @@ through2@^2.0.0:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
-
-through@^2.3.8:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timers-browserify@^2.0.4:
   version "2.0.12"
@@ -5546,14 +5391,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-unbzip2-stream@^1.3.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
-  dependencies:
-    buffer "^5.2.1"
-    through "^2.3.8"
 
 unherit@^1.0.4:
   version "1.1.3"
@@ -6000,11 +5837,3 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- remove puppeteer dependency, use puppeteer-core with custom chromium binary instead
- change plugin id from `opendistroKibanaReports` to `opendistroReportsKibana` for consistency
- add chromium path parameter to `createVisualReport` for jest testing
- update github workflows to build artifacts for windows and linux
- add s3 bucket path in release workflow
- use `path.posix.normalize` instead of `path.normalize` when verifying URL to accommodate Windows

## Caveats
- Chromium binary has to be downloaded separately if running from source, but will be packed by github actions in the zip artifact
- <del>Chromium path defaults to `./plugins/opendistroReportsKibana/.chromium/headless_shell` which works for the zip artifact, but if running from source it should be `./plugins/kibana-reports/.chromium/headless_shell`</del> (Fixed by #236 )
- Ubuntu needs additional dependencies to run chromium 
```
sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
```
- RedHat/CentOS needs additional dependencies to run chromium
```
sudo yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
