### PR TITLE
[Bug fix] Use default max size to call getAll ES API

### DIFF
--- a/kibana-reports/public/components/main/main.tsx
+++ b/kibana-reports/public/components/main/main.tsx
@@ -36,7 +36,6 @@ import {
   permissionsMissingToast,
   permissionsMissingActions,
 } from '../utils/utils';
-import { HttpSetup } from '../../../../../src/core/public/http/types';
 
 const reportCountStyles: CSS.Properties = {
   color: 'gray',

--- a/kibana-reports/public/components/main/main.tsx
+++ b/kibana-reports/public/components/main/main.tsx
@@ -36,6 +36,7 @@ import {
   permissionsMissingToast,
   permissionsMissingActions,
 } from '../utils/utils';
+import { HttpSetup } from '../../../../../src/core/public/http/types';
 
 const reportCountStyles: CSS.Properties = {
   color: 'gray',
@@ -165,7 +166,7 @@ export function Main(props) {
 
   const pagination = {
     initialPageSize: 10,
-    pageSizeOptions: [8, 10, 13],
+    pageSizeOptions: [5, 10, 20],
   };
 
   useEffect(() => {

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -561,9 +561,7 @@ export function ReportTrigger(props: ReportTriggerProps) {
           if (!edit) {
             reportDefinitionRequest.trigger.trigger_params.enabled = true;
           }
-          console.log(JSON.stringify(reportDefinitionRequest.trigger));
           if (!('enabled' in reportDefinitionRequest.trigger.trigger_params)) {
-            console.log('get in to block');
             reportDefinitionRequest.trigger.trigger_params.enabled = true;
           }
         }

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -561,8 +561,10 @@ export function ReportTrigger(props: ReportTriggerProps) {
           if (!edit) {
             reportDefinitionRequest.trigger.trigger_params.enabled = true;
           }
+          console.log(JSON.stringify(reportDefinitionRequest.trigger));
           if (!('enabled' in reportDefinitionRequest.trigger.trigger_params)) {
-            reportDefinitionRequest.trigger.trigger_params.enabled = false;
+            console.log('get in to block');
+            reportDefinitionRequest.trigger.trigger_params.enabled = true;
           }
         }
       });

--- a/kibana-reports/server/backend/opendistro-es-reports-plugin.ts
+++ b/kibana-reports/server/backend/opendistro-es-reports-plugin.ts
@@ -76,13 +76,14 @@ export default function (Client: any, config: any, components: any) {
   esReports.getReports = clientAction({
     url: {
       fmt: `${ES_REPORTS_API.LIST_REPORT_INSTANCES}`,
-      //TODO: wrong format error thrown even required = false, need to figure it out the correct setting to make it truly optional
-      // req: {
-      //   fromIndex: {
-      //     type: 'string',
-      //     required: false,
-      //   },
-      // },
+      params: {
+        fromIndex: {
+          type: 'number',
+        },
+        maxItems: {
+          type: 'number',
+        },
+      },
     },
     method: 'GET',
   });
@@ -128,13 +129,14 @@ export default function (Client: any, config: any, components: any) {
   esReports.getReportDefinitions = clientAction({
     url: {
       fmt: `${ES_REPORTS_API.LIST_REPORT_DEFINITIONS}`,
-      //TODO: wrong format error thrown even required = false, need to figure it out the correct setting to make it truly optional
-      // req: {
-      //   fromIndex: {
-      //     type: 'string',
-      //     required: false,
-      //   },
-      // },
+      params: {
+        fromIndex: {
+          type: 'number',
+        },
+        maxItems: {
+          type: 'number',
+        },
+      },
     },
     method: 'GET',
   });

--- a/kibana-reports/server/routes/report.ts
+++ b/kibana-reports/server/routes/report.ts
@@ -25,7 +25,7 @@ import { API_PREFIX } from '../../common';
 import { createReport } from './lib/createReport';
 import { reportSchema } from '../model';
 import { errorResponse } from './utils/helpers';
-import { DELIVERY_TYPE } from './utils/constants';
+import { DEFAULT_MAX_SIZE, DELIVERY_TYPE } from './utils/constants';
 import {
   backendToUiReport,
   backendToUiReportsList,
@@ -206,10 +206,8 @@ export default function (router: IRouter) {
       path: `${API_PREFIX}/reports`,
       validate: {
         query: schema.object({
-          size: schema.maybe(schema.string()),
-          sortField: schema.maybe(schema.string()),
-          sortDirection: schema.maybe(schema.string()),
-          fromIndex: schema.maybe(schema.string()),
+          fromIndex: schema.maybe(schema.number()),
+          maxItems: schema.maybe(schema.number()),
         }),
       },
     },
@@ -218,11 +216,9 @@ export default function (router: IRouter) {
       request,
       response
     ): Promise<IKibanaResponse<any | ResponseError>> => {
-      const { fromIndex } = request.query as {
-        size: string;
-        sortField: string;
-        sortDirection: string;
-        fromIndex: string;
+      const { fromIndex, maxItems } = request.query as {
+        fromIndex: number;
+        maxItems: number;
       };
 
       try {
@@ -230,11 +226,11 @@ export default function (router: IRouter) {
         const esReportsClient: ILegacyScopedClusterClient = context.reporting_plugin.esReportsClient.asScoped(
           request
         );
-
         const esResp = await esReportsClient.callAsCurrentUser(
           'es_reports.getReports',
           {
             fromIndex: fromIndex,
+            maxItems: maxItems || DEFAULT_MAX_SIZE,
           }
         );
 

--- a/kibana-reports/server/routes/reportDefinition.ts
+++ b/kibana-reports/server/routes/reportDefinition.ts
@@ -29,6 +29,7 @@ import {
   backendToUiReportDefinitionsList,
 } from './utils/converters/backendToUi';
 import { updateReportDefinition } from './lib/updateReportDefinition';
+import { DEFAULT_MAX_SIZE } from './utils/constants';
 
 export default function (router: IRouter) {
   // Create report Definition
@@ -137,10 +138,8 @@ export default function (router: IRouter) {
       path: `${API_PREFIX}/reportDefinitions`,
       validate: {
         query: schema.object({
-          size: schema.maybe(schema.string()),
-          sortField: schema.maybe(schema.string()),
-          sortDirection: schema.maybe(schema.string()),
-          fromIndex: schema.maybe(schema.string()),
+          fromIndex: schema.maybe(schema.number()),
+          maxItems: schema.maybe(schema.number()),
         }),
       },
     },
@@ -149,11 +148,9 @@ export default function (router: IRouter) {
       request,
       response
     ): Promise<IKibanaResponse<any | ResponseError>> => {
-      const { fromIndex } = request.query as {
-        size: string;
-        sortField: string;
-        sortDirection: string;
-        fromIndex: string;
+      const { fromIndex, maxItems } = request.query as {
+        fromIndex: number;
+        maxItems: number;
       };
 
       try {
@@ -166,6 +163,7 @@ export default function (router: IRouter) {
           'es_reports.getReportDefinitions',
           {
             fromIndex: fromIndex,
+            maxItems: maxItems || DEFAULT_MAX_SIZE,
           }
         );
 


### PR DESCRIPTION
*Issue #, if available:*

The default query size in ES side is set to 100, should pass in parameter if we want to retrieve more data

*Description of changes:*
- From Kibana side, add `fromIndex` and `maxItems` as optional params, and use default value `10000` for `maxItems`.
- Test with 10000 report instances added. Browser response time is within 4 secs. It's tolerable for the initial release.
- TODO: need to implement pagination in the EUI, currently the table eui component is [EuiInMemoryTable](https://elastic.github.io/eui/#/tabular-content/in-memory-tables), which requires all possible data to be loaded. Need to consider use low level components such as `EuiBasicTable` along with `EuiPagination`, `EuiSearchBar`

#### Others
- set enabled field to be true when switching from on-demand to scheduled report definition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
