### PR TITLE
Lock Edit report source and Input Validation

### DIFF
--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -34,11 +34,34 @@ import {
   permissionsMissingToast,
   permissionsMissingActions,
 } from '../../utils/utils';
+import { definitionInputValidation } from '../utils/utils';
 
 export function EditReportDefinition(props) {
   const [toasts, setToasts] = useState([]);
   const [comingFromError, setComingFromError] = useState(false);
   const [preErrorData, setPreErrorData] = useState({});
+
+  const [
+    showSettingsReportNameError,
+    setShowSettingsReportNameError,
+  ] = useState(false);
+  const [
+    settingsReportNameErrorMessage,
+    setSettingsReportNameErrorMessage,
+  ] = useState('');
+  const [
+    showTriggerIntervalNaNError,
+    setShowTriggerIntervalNaNError,
+  ] = useState(false);
+  const [showCronError, setShowCronError] = useState(false);
+  const [showEmailRecipientsError, setShowEmailRecipientsError] = useState(
+    false
+  );
+  const [
+    emailRecipientsErrorMessage,
+    setEmailRecipientsErrorMessage,
+  ] = useState('');
+  const [showTimeRangeError, setShowTimeRangeError] = useState(false);
 
   const addPermissionsMissingViewEditPageToastHandler = (errorType: string) => {
     let toast = {};
@@ -151,7 +174,6 @@ export function EditReportDefinition(props) {
 
   const callUpdateAPI = async (metadata) => {
     const { httpClient } = props;
-
     httpClient
       .put(`../api/reporting/reportDefinitions/${reportDefinitionId}`, {
         body: JSON.stringify(metadata),
@@ -175,7 +197,6 @@ export function EditReportDefinition(props) {
   };
 
   const editReportDefinition = async (metadata) => {
-    const { httpClient } = props;
     if ('header' in metadata.report_params.core_params) {
       metadata.report_params.core_params.header = converter.makeHtml(
         metadata.report_params.core_params.header
@@ -186,30 +207,27 @@ export function EditReportDefinition(props) {
         metadata.report_params.core_params.footer
       );
     }
-    /*
-      we check if this editing updates the trigger type from Schedule to On demand. 
-      If so, need to first delete the reportDefinition along with the scheduled job first, by calling the delete
-      report definition API
-    */
-    const {
-      trigger: { trigger_type: triggerType },
-    } = reportDefinition;
-    if (
-      triggerType !== 'On demand' &&
-      metadata.trigger.trigger_type === 'On demand'
-    ) {
-      httpClient
-        .delete(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
-        .then(async () => {
-          await callUpdateAPI(metadata);
-        })
-        .catch((error) => {
-          console.log(
-            'error when deleting old scheduled report definition:',
-            error
-          );
-          handleErrorDeletingReportDefinitionToast();
-        });
+    
+    // client-side input validation
+    let error = false;
+    await definitionInputValidation(
+      metadata,
+      error,
+      setShowSettingsReportNameError,
+      setSettingsReportNameErrorMessage,
+      setShowTriggerIntervalNaNError,
+      timeRange,
+      setShowTimeRangeError,
+      setShowCronError,
+      setShowEmailRecipientsError,
+      setEmailRecipientsErrorMessage
+    ).then((response) => {
+      error = response;
+    });
+    if (error) {
+      handleInputValidationErrorToast();
+      setPreErrorData(metadata);
+      setComingFromError(true);
     } else {
       await callUpdateAPI(metadata);
     }
@@ -273,6 +291,9 @@ export function EditReportDefinition(props) {
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}
           timeRange={timeRange}
+          showSettingsReportNameError={showSettingsReportNameError}
+          settingsReportNameErrorMessage={settingsReportNameErrorMessage}
+          showTimeRangeError={showTimeRangeError}
         />
         <EuiSpacer />
         <ReportTrigger
@@ -281,6 +302,8 @@ export function EditReportDefinition(props) {
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}
           timeRange={timeRange}
+          showTriggerIntervalNaNError={showTriggerIntervalNaNError}
+          showCronError={showCronError}
         />
         <EuiSpacer />
         <ReportDelivery
@@ -289,6 +312,8 @@ export function EditReportDefinition(props) {
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}
           timeRange={timeRange}
+          showEmailRecipientsError={showEmailRecipientsError}
+          emailRecipientsErrorMessage={emailRecipientsErrorMessage}
         />
         <EuiSpacer />
         <EuiFlexGroup justifyContent="flexEnd">

--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -54,9 +54,10 @@ export function EditReportDefinition(props) {
     setShowTriggerIntervalNaNError,
   ] = useState(false);
   const [showCronError, setShowCronError] = useState(false);
-  const [showEmailRecipientsError, setShowEmailRecipientsError] = useState(
-    false
-  );
+  const [
+    showEmailRecipientsError, 
+    setShowEmailRecipientsError
+  ] = useState(false);
   const [
     emailRecipientsErrorMessage,
     setEmailRecipientsErrorMessage,

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
@@ -2748,6 +2748,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
             <input
               checked=""
               class="euiRadio__input"
+              disabled=""
               id="dashboardReportSource"
               type="radio"
               value=""
@@ -2767,6 +2768,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
           >
             <input
               class="euiRadio__input"
+              disabled=""
               id="visualizationReportSource"
               type="radio"
               value=""
@@ -2786,6 +2788,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
           >
             <input
               class="euiRadio__input"
+              disabled=""
               id="savedSearchReportSource"
               type="radio"
               value=""
@@ -3248,6 +3251,7 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
             <input
               checked=""
               class="euiRadio__input"
+              disabled=""
               id="dashboardReportSource"
               type="radio"
               value=""
@@ -3267,6 +3271,7 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
           >
             <input
               class="euiRadio__input"
+              disabled=""
               id="visualizationReportSource"
               type="radio"
               value=""
@@ -3286,6 +3291,7 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
           >
             <input
               class="euiRadio__input"
+              disabled=""
               id="savedSearchReportSource"
               type="radio"
               value=""
@@ -3748,6 +3754,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
             <input
               checked=""
               class="euiRadio__input"
+              disabled=""
               id="dashboardReportSource"
               type="radio"
               value=""
@@ -3767,6 +3774,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
           >
             <input
               class="euiRadio__input"
+              disabled=""
               id="visualizationReportSource"
               type="radio"
               value=""
@@ -3786,6 +3794,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
           >
             <input
               class="euiRadio__input"
+              disabled=""
               id="savedSearchReportSource"
               type="radio"
               value=""

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -672,6 +672,7 @@ export function ReportSettings(props: ReportSettingProps) {
             options={REPORT_SOURCE_RADIOS}
             idSelected={reportSourceId}
             onChange={handleReportSource}
+            disabled={edit}
           />
         </EuiFormRow>
         <EuiSpacer />

--- a/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -71,7 +71,7 @@ export function TimeRangeSelect(props) {
       if (
         !timeRangeMoment ||
         !timeRangeMoment.isValid() ||
-        timeRangeMoment > moment()
+        timeRangeMoment > moment.now()
       ) {
         handleInvalidTimeRangeToast();
       }

--- a/kibana-reports/public/components/report_definitions/utils/utils.tsx
+++ b/kibana-reports/public/components/report_definitions/utils/utils.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { isValidCron } from "cron-validator";
+import moment from "moment";
+
+ export const definitionInputValidation = async (
+     metadata, 
+     error,
+     setShowSettingsReportNameError,
+     setSettingsReportNameErrorMessage,
+     setShowTriggerIntervalNaNError,
+     timeRange,
+     setShowTimeRangeError,
+     setShowCronError,
+     setShowEmailRecipientsError,
+     setEmailRecipientsErrorMessage
+    ) => {
+    // check report name
+    // allow a-z, A-Z, 0-9, (), [], ',' - and _ and spaces
+    let regexp = /^[\w\-\s\(\)\[\]\,\_\-+]+$/;
+    if (metadata.report_params.report_name.search(regexp) === -1) {
+      setShowSettingsReportNameError(true);
+      if (metadata.report_params.report_name === '') {
+        setSettingsReportNameErrorMessage('Name must not be empty.');
+      } else {
+        setSettingsReportNameErrorMessage('Invalid characters in report name.');
+      }
+      error = true;
+    }
+
+    // if recurring by interval and input is not a number
+    if (
+      metadata.trigger.trigger_type === 'Schedule' &&
+      metadata.trigger.trigger_params.schedule_type === 'Recurring'
+    ) {
+      let interval = parseInt(
+        metadata.trigger.trigger_params.schedule.interval.period
+      );
+      if (isNaN(interval)) {
+        setShowTriggerIntervalNaNError(true);
+        error = true;
+      }
+    }
+
+    // if time range is invalid
+    const nowDate = new Date(moment.now());
+    console.log('time to is', timeRange.timeTo);
+    console.log('now date is', nowDate);
+    if (timeRange.timeFrom > timeRange.timeTo || timeRange.timeTo > nowDate) {
+      setShowTimeRangeError(true);
+      error = true;
+    }
+
+    // if cron based and cron input is invalid
+    if (
+      metadata.trigger.trigger_type === 'Schedule' &&
+      metadata.trigger.trigger_params.schedule_type === 'Cron based'
+    ) {
+      if (
+        !isValidCron(metadata.trigger.trigger_params.schedule.cron.expression)
+      ) {
+        setShowCronError(true);
+        error = true;
+      }
+    }
+    // if email delivery
+    if (metadata.delivery.delivery_type === 'Channel') {
+      // no recipients are listed
+      if (metadata.delivery.delivery_params.recipients.length === 0) {
+        setShowEmailRecipientsError(true);
+        setEmailRecipientsErrorMessage(
+          'Email recipients list cannot be empty.'
+        );
+        error = true;
+      }
+      // recipients have invalid email addresses: regexp checks format xxxxx@yyyy.zzz
+      let emailRegExp = /\S+@\S+\.\S+/;
+      let index;
+      let recipients = metadata.delivery.delivery_params.recipients;
+      for (index = 0; index < recipients.length; ++index) {
+        if (recipients[0].search(emailRegExp) === -1) {
+          setShowEmailRecipientsError(true);
+          setEmailRecipientsErrorMessage(
+            'Invalid email addresses in recipients list.'
+          );
+          error = true;
+        }
+      }
+    }
+    return error;
+  };

--- a/kibana-reports/public/components/report_definitions/utils/utils.tsx
+++ b/kibana-reports/public/components/report_definitions/utils/utils.tsx
@@ -57,8 +57,6 @@ import moment from "moment";
 
     // if time range is invalid
     const nowDate = new Date(moment.now());
-    console.log('time to is', timeRange.timeTo);
-    console.log('now date is', nowDate);
     if (timeRange.timeFrom > timeRange.timeTo || timeRange.timeTo > nowDate) {
       setShowTimeRangeError(true);
       error = true;


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Added client-side input validation for `Edit` identical to that of `Create`. Locked the `Report source` field so that users cannot change their report source when editing a report definition. Also removed old `Edit` structure to no longer delete existing report definition `onClick` in `Edit report definition`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
