### PR TITLE
Update workflow to build artifact for ARM64

### DIFF
--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -37,50 +37,58 @@ jobs:
           node-version: "10.22.1"
 
       - name: Move Kibana Reports to Plugins Dir
-        run: mv kibana-reports kibana/plugins/opendistroReportsKibana
+        run: mv kibana-reports kibana/plugins/${{ env.PLUGIN_NAME }}
+
+      - name: Add Chromium Binary to Reporting for Testing
+        run: |
+          sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
+          cd kibana/plugins/${{ env.PLUGIN_NAME }}
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
+          unzip chromium-linux-x64.zip
+          rm chromium-linux-x64.zip
 
       - name: Kibana Plugin Bootstrap
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/opendistroReportsKibana; yarn kbn bootstrap
+          command: cd kibana/plugins/${{ env.PLUGIN_NAME }}; yarn kbn bootstrap
 
       - name: Test
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/opendistroReportsKibana; yarn test
+          command: cd kibana/plugins/${{ env.PLUGIN_NAME }}; yarn test
 
       - name: Build Artifact
         run: |
-          cd kibana/plugins/opendistroReportsKibana
+          cd kibana/plugins/${{ env.PLUGIN_NAME }}
           yarn build
 
           cd build
-          mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/opendistroReportsKibana
+          mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/${{ env.PLUGIN_NAME }}
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
           mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
           cd linux-x64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
-          unzip chromium-linux-x64.zip -d ./kibana/opendistroReportsKibana
+          unzip chromium-linux-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
           cd linux-arm64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-arm64.zip
-          unzip chromium-linux-arm64.zip -d ./kibana/opendistroReportsKibana
+          unzip chromium-linux-arm64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
           cd windows-x64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows-x64.zip
-          unzip chromium-windows-x64.zip -d ./kibana/opendistroReportsKibana
+          unzip chromium-windows-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -59,9 +59,9 @@ jobs:
           yarn build
 
           cd build
-          mkdir -p ./{linux-x64,linux-amd64,windows-x64}/kibana/opendistroReportsKibana
+          mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/opendistroReportsKibana
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-amd64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-amd64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
           mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
           cd linux-x64
@@ -71,9 +71,9 @@ jobs:
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
-          cd linux-amd64
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-amd64.zip
-          unzip chromium-linux-amd64.zip -d ./kibana/opendistroReportsKibana
+          cd linux-arm64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-arm64.zip
+          unzip chromium-linux-arm64.zip -d ./kibana/opendistroReportsKibana
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -59,20 +59,28 @@ jobs:
           yarn build
 
           cd build
-          mkdir -p ./{linux,windows}/kibana/opendistroReportsKibana
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
-          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          mkdir -p ./{linux-x64,linux-amd64,windows-x64}/kibana/opendistroReportsKibana
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-amd64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-amd64.zip
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
-          cd linux
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
-          unzip chromium-linux.zip -d ./kibana/opendistroReportsKibana
+          cd linux-x64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
+          unzip chromium-linux-x64.zip -d ./kibana/opendistroReportsKibana
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
-          cd windows
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows.zip
-          unzip chromium-windows.zip -d ./kibana/opendistroReportsKibana
+          cd linux-amd64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-amd64.zip
+          unzip chromium-linux-amd64.zip -d ./kibana/opendistroReportsKibana
+          zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ..
+          cd ..
+
+          cd windows-x64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows-x64.zip
+          unzip chromium-windows-x64.zip -d ./kibana/opendistroReportsKibana
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
           cd kibana/plugins/opendistroReportsKibana
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
-          unzip chromium-linux.zip
-          rm chromium-linux.zip
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
+          unzip chromium-linux-x64.zip
+          rm chromium-linux-x64.zip
 
       - name: Kibana Plugin Bootstrap
         uses: nick-invision/retry@v1
@@ -56,9 +56,9 @@ jobs:
           yarn build
 
           cd build
-          mkdir -p ./{linux-x64,linux-amd64,windows-x64}/kibana/opendistroReportsKibana
+          mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/opendistroReportsKibana
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-amd64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-amd64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
           mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
           cd linux-x64
@@ -68,9 +68,9 @@ jobs:
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
-          cd linux-amd64
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-amd64.zip
-          unzip chromium-linux-amd64.zip -d ./kibana/opendistroReportsKibana
+          cd linux-arm64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-arm64.zip
+          unzip chromium-linux-arm64.zip -d ./kibana/opendistroReportsKibana
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
@@ -88,11 +88,11 @@ jobs:
           name: kibana-reports-linux-x64
           path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
 
-      - name: Upload Artifact For Linux amd64
+      - name: Upload Artifact For Linux arm64
         uses: actions/upload-artifact@v1
         with:
-          name: kibana-reports-linux-amd64
-          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-amd64.zip
+          name: kibana-reports-linux-arm64
+          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
 
       - name: Upload Artifact For Windows
         uses: actions/upload-artifact@v1

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -26,12 +26,12 @@ jobs:
           node-version: "10.22.1"
 
       - name: Move Kibana Reports to Plugins Dir
-        run: mv kibana-reports kibana/plugins/opendistroReportsKibana
+        run: mv kibana-reports kibana/plugins/${{ env.PLUGIN_NAME }}
 
       - name: Add Chromium Binary to Reporting for Testing
         run: |
           sudo apt install -y libnss3-dev fonts-liberation libfontconfig1
-          cd kibana/plugins/opendistroReportsKibana
+          cd kibana/plugins/${{ env.PLUGIN_NAME }}
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
           unzip chromium-linux-x64.zip
           rm chromium-linux-x64.zip
@@ -41,43 +41,43 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/opendistroReportsKibana; yarn kbn bootstrap
+          command: cd kibana/plugins/${{ env.PLUGIN_NAME }}; yarn kbn bootstrap
 
       - name: Test
         uses: nick-invision/retry@v1
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: cd kibana/plugins/opendistroReportsKibana; yarn test
+          command: cd kibana/plugins/${{ env.PLUGIN_NAME }}; yarn test
 
       - name: Build Artifact
         run: |
-          cd kibana/plugins/opendistroReportsKibana
+          cd kibana/plugins/${{ env.PLUGIN_NAME }}
           yarn build
 
           cd build
-          mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/opendistroReportsKibana
+          mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/${{ env.PLUGIN_NAME }}
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
           mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
           cd linux-x64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
-          unzip chromium-linux-x64.zip -d ./kibana/opendistroReportsKibana
+          unzip chromium-linux-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
           cd linux-arm64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-arm64.zip
-          unzip chromium-linux-arm64.zip -d ./kibana/opendistroReportsKibana
+          unzip chromium-linux-arm64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
           cd windows-x64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows-x64.zip
-          unzip chromium-windows-x64.zip -d ./kibana/opendistroReportsKibana
+          unzip chromium-windows-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
@@ -86,16 +86,16 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: kibana-reports-linux-x64
-          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          path: kibana/plugins/${{ env.PLUGIN_NAME }}/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
 
       - name: Upload Artifact For Linux arm64
         uses: actions/upload-artifact@v1
         with:
           name: kibana-reports-linux-arm64
-          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
+          path: kibana/plugins/${{ env.PLUGIN_NAME }}/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
 
       - name: Upload Artifact For Windows
         uses: actions/upload-artifact@v1
         with:
           name: kibana-reports-windows-x64
-          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          path: kibana/plugins/${{ env.PLUGIN_NAME }}/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -56,32 +56,46 @@ jobs:
           yarn build
 
           cd build
-          mkdir -p ./{linux,windows}/kibana/opendistroReportsKibana
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
-          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
+          mkdir -p ./{linux-x64,linux-amd64,windows-x64}/kibana/opendistroReportsKibana
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-amd64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-amd64.zip
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
-          cd linux
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux.zip
-          unzip chromium-linux.zip -d ./kibana/opendistroReportsKibana
+          cd linux-x64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
+          unzip chromium-linux-x64.zip -d ./kibana/opendistroReportsKibana
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
-          cd windows
-          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows.zip
-          unzip chromium-windows.zip -d ./kibana/opendistroReportsKibana
+          cd linux-amd64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-amd64.zip
+          unzip chromium-linux-amd64.zip -d ./kibana/opendistroReportsKibana
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           mv ./${{ env.PLUGIN_NAME }}-*.zip ..
           cd ..
 
-      - name: Upload Artifact For Linux
+          cd windows-x64
+          wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-windows-x64.zip
+          unzip chromium-windows-x64.zip -d ./kibana/opendistroReportsKibana
+          zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ..
+          cd ..
+
+      - name: Upload Artifact For Linux x64
         uses: actions/upload-artifact@v1
         with:
-          name: kibana-reports-linux
+          name: kibana-reports-linux-x64
           path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+
+      - name: Upload Artifact For Linux amd64
+        uses: actions/upload-artifact@v1
+        with:
+          name: kibana-reports-linux-amd64
+          path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-amd64.zip
 
       - name: Upload Artifact For Windows
         uses: actions/upload-artifact@v1
         with:
-          name: kibana-reports-windows
+          name: kibana-reports-windows-x64
           path: kibana/plugins/opendistroReportsKibana/build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip

--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -30,6 +30,7 @@
     "jquery": "^3.5.0",
     "jsdom": "13.1.0",
     "json-2-csv": "^3.7.6",
+    "puppeteer-core": "^1.19.0",
     "react-addons-test-utils": "^15.6.2",
     "react-id-generator": "^3.0.1",
     "react-markdown": "^4.3.1",

--- a/kibana-reports/yarn.lock
+++ b/kibana-reports/yarn.lock
@@ -863,6 +863,13 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
+agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
 airbnb-prop-types@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz#b96274cefa1abb14f623f804173ee97c13971dc2"
@@ -1355,6 +1362,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
 buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1658,7 +1670,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -1858,6 +1870,13 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 debug@^4.1.0:
   version "4.1.1"
@@ -2252,6 +2271,18 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2428,6 +2459,16 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^1.6.6:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
+  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
+  dependencies:
+    concat-stream "^1.6.2"
+    debug "^2.6.9"
+    mkdirp "^0.5.4"
+    yauzl "^2.10.0"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -2459,6 +2500,13 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -2871,6 +2919,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^2.2.1:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
+  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
 
 i18n-js@3.0.11:
   version "3.0.11"
@@ -3776,6 +3832,11 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.44.0"
 
+mime@^2.0.3:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
+  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
 mini-create-react-context@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz#df60501c83151db69e28eac0ef08b4002efab040"
@@ -3835,7 +3896,7 @@ mkdirp@1.x:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^0.5.1, mkdirp@^0.5.3:
+mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -4248,6 +4309,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -4312,6 +4378,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -4339,6 +4410,11 @@ prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+proxy-from-env@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -4406,6 +4482,20 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+puppeteer-core@^1.19.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-1.20.0.tgz#cfad0c7cbb6e9bb0d307c6e955e5c924134bbeb5"
+  integrity sha512-akoSCMDVv6BFd/4+dtW6mVgdaRQhy/cmkGzXcx9HAXZqnY9zXYbsfoXMiMpwt3+53U9zFGSjgvsi0mDKNJLfqg==
+  dependencies:
+    debug "^4.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
+    progress "^2.0.1"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^6.1.0"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -4768,7 +4858,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -5743,7 +5833,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^6.1.2:
+ws@^6.1.0, ws@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
@@ -5844,3 +5934,11 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- adds linux arm64 builds in addition to linux x64 and windows in #222 
- renamed chromium binaries to include architecture information
- add `puppeteer-core` as it's not included in kibana-oss

Artifact names:
`opendistroReportsKibana-1.12.0.0-linux-x64.zip`
`opendistroReportsKibana-1.12.0.0-linux-arm64.zip`
`opendistroReportsKibana-1.12.0.0-windows-x64.zip`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
