### PR TITLE
Fix chromium path for puppeteer

### DIFF
--- a/kibana-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
+++ b/kibana-reports/server/routes/utils/__tests__/visualReportHelper.test.ts
@@ -74,9 +74,7 @@ describe('test create visual report', () => {
     const { dataUrl, fileName } = await createVisualReport(
       reportParams as ReportParamsSchemaType,
       queryUrl,
-      mockLogger,
-      undefined,
-      './.chromium/headless_shell'
+      mockLogger
     );
     expect(fileName).toContain(`${reportParams.report_name}`);
     expect(fileName).toContain('.png');
@@ -91,9 +89,7 @@ describe('test create visual report', () => {
     const { dataUrl, fileName } = await createVisualReport(
       reportParams as ReportParamsSchemaType,
       queryUrl,
-      mockLogger,
-      undefined,
-      './.chromium/headless_shell'
+      mockLogger
     );
     expect(fileName).toContain(`${reportParams.report_name}`);
     expect(fileName).toContain('.pdf');

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+import { PLUGIN_ID } from '../../../common';
+
 export enum FORMAT {
   pdf = 'pdf',
   png = 'png',
@@ -79,9 +81,9 @@ export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 export const SECURITY_AUTH_COOKIE_NAME = 'security_authentication';
 
 export const CHROMIUM_PATHS = [
-  './plugins/opendistroReportsKibana/.chromium/headless_shell',
+  `./plugins/${PLUGIN_ID}/.chromium/headless_shell`,
   './plugins/kibana-reports/.chromium/headless_shell',
   './.chromium/headless_shell',
-  '../plugins/opendistroReportsKibana/.chromium/headless_shell',
+  `../plugins/${PLUGIN_ID}/.chromium/headless_shell`,
   '../plugins/kibana-reports/.chromium/headless_shell',
 ];

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -78,5 +78,8 @@ export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 
 export const SECURITY_AUTH_COOKIE_NAME = 'security_authentication';
 
-export const CHROMIUM_PATH =
-  './plugins/opendistroReportsKibana/.chromium/headless_shell';
+export const CHROMIUM_PATHS = [
+  './plugins/opendistroReportsKibana/.chromium/headless_shell',
+  './plugins/kibana-reports/.chromium/headless_shell',
+  './.chromium/headless_shell',
+];

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -51,11 +51,13 @@ export const createVisualReport = async (
   } = coreParams;
 
   const getChromiumPath = () => {
-    return CHROMIUM_PATHS.find((path) => {
+    const path = CHROMIUM_PATHS.find((path) => {
       try {
         return fs.existsSync(path);
       } catch (error) {}
     });
+    if (path) return path;
+    logger.error('cannot find headless chromium for puppeteer');
   };
 
   // TODO: polish default header, maybe add a logo, depends on UX design

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -22,7 +22,7 @@ import {
   REPORT_TYPE,
   FORMAT,
   SELECTOR,
-  CHROMIUM_PATH,
+  CHROMIUM_PATHS,
 } from '../constants';
 import { getFileName } from '../helpers';
 import { CreateReportResultType } from '../types';
@@ -34,8 +34,7 @@ export const createVisualReport = async (
   reportParams: ReportParamsSchemaType,
   queryUrl: string,
   logger: Logger,
-  cookie?: SetCookie,
-  chromiumPath = CHROMIUM_PATH
+  cookie?: SetCookie
 ): Promise<CreateReportResultType> => {
   const {
     core_params,
@@ -50,6 +49,14 @@ export const createVisualReport = async (
     window_width: windowWidth,
     report_format: reportFormat,
   } = coreParams;
+
+  const getChromiumPath = () => {
+    return CHROMIUM_PATHS.find((path) => {
+      try {
+        return fs.existsSync(path);
+      } catch (error) {}
+    });
+  };
 
   // TODO: polish default header, maybe add a logo, depends on UX design
   const window = new JSDOM('').window;
@@ -68,7 +75,7 @@ export const createVisualReport = async (
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
     args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    executablePath: chromiumPath,
+    executablePath: getChromiumPath(),
   });
   const page = await browser.newPage();
   page.setDefaultNavigationTimeout(0);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
check for chromium path for puppeteer to use instead of using a constant path

possible chromium paths:
```
  './plugins/opendistroReportsKibana/.chromium/headless_shell',
  './plugins/kibana-reports/.chromium/headless_shell',
  './.chromium/headless_shell',
  '../plugins/opendistroReportsKibana/.chromium/headless_shell',
  '../plugins/kibana-reports/.chromium/headless_shell',
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
