### PR TITLE
Disable gpu on chromium

### DIFF
--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -66,7 +66,7 @@ export const createVisualReport = async (
      * TODO: temp fix to disable sandbox when launching chromium on Linux instance
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
-    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
     executablePath: CHROMIUM_PATH,
   });
   const page = await browser.newPage();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `--disable-gpu` flag for puppeteer, otherwise chromium crashes when using deb or rpm kibana. This doesn't seem to affect zip/tar/source version of kibana. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
