### PR TITLE
Add Custom Common Time Ranges

### DIFF
--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -65,3 +65,26 @@ export const REPORT_SOURCE_TYPES = {
   visualization: 'Visualization',
   savedSearch: 'Saved search',
 };
+
+export const commonTimeRanges = [
+  {
+    start: 'now/d',
+    end: 'now',
+    label: 'Today so far'
+  },
+  {
+    start: 'now/w',
+    end: 'now',
+    label: 'Week to date'
+  },
+  {
+    start: 'now/M',
+    end: 'now',
+    label: 'Month to date'
+  },
+  {
+    start: 'now/y',
+    end: 'now',
+    label: 'Year to date'
+  }
+]

--- a/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -22,6 +22,7 @@ import {
   EuiGlobalToastList,
   EuiSuperDatePicker,
 } from '@elastic/eui';
+import { commonTimeRanges } from './report_settings_constants';
 
 export function TimeRangeSelect(props) {
   const {
@@ -191,6 +192,7 @@ export function TimeRangeSelect(props) {
     setIsLoading(false);
   };
 
+
   return (
     <div>
       <div>
@@ -207,6 +209,7 @@ export function TimeRangeSelect(props) {
             end={end}
             onTimeChange={onTimeChange}
             showUpdateButton={false}
+            commonlyUsedRanges={commonTimeRanges}
           />
         </EuiFormRow>
       </div>


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
The default custom time ranges in the date picker end up with invalid time ranges. Replacing them with custom time ranges that don't violate our time range:
* Today so far
* Week to date
* Month to date
* Year to date 

![Screen Shot 2020-12-03 at 9 50 33 AM](https://user-images.githubusercontent.com/53581635/101069806-5635ff80-354f-11eb-9536-d255d34761dc.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
