### PR TITLE
add double dots to relative url in fetch()

### DIFF
--- a/kibana-reports/public/components/context_menu/context_menu.js
+++ b/kibana-reports/public/components/context_menu/context_menu.js
@@ -98,7 +98,7 @@ const generateInContextReport = (
   };
 
   fetch(
-    `/api/reporting/generateReport?timezone=${
+    `../api/reporting/generateReport?timezone=${
       Intl.DateTimeFormat().resolvedOptions().timeZone
     }`,
     {


### PR DESCRIPTION
*Issue #, if available:*
in-context menu download fails when 'server.basepath' in kibana.yml is configured, by default it's empty string.

*Description of changes:*
- Add 2 dots to use relative url, just like how we call API in other places such as create report definition, getAll reports/report definition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
