### PR TITLE
Optimize selectors for DOM operation to reduce possible version compatibility issue 

### DIFF
--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -68,7 +68,6 @@ export enum DELIVERY_TYPE {
 export enum SELECTOR {
   dashboard = '#dashboardViewport',
   visualization = '.visEditor__content',
-  topNavBar = '#globalHeaderBars',
 }
 
 // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-from-size.html

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -51,7 +51,6 @@ export const createVisualReport = async (
     report_format: reportFormat,
   } = coreParams;
 
-  // TODO: polish default header, maybe add a logo, depends on UX design
   const window = new JSDOM('').window;
   const DOMPurify = createDOMPurify(window);
 
@@ -93,16 +92,17 @@ export const createVisualReport = async (
   // remove top nav bar
   await page.evaluate(
     /* istanbul ignore next */
-    (selector) => {
-      document.querySelector(selector)?.remove();
+    () => {
+      // remove buttons
       document
         .querySelectorAll("[class^='euiButton']")
         .forEach((e) => e.remove());
-      document.querySelector(
-        '.coreSystemRootDomElement.euiBody--headerIsFixed'
-      ).style.paddingTop = '0px';
-    },
-    SELECTOR.topNavBar
+      // remove top navBar
+      document
+        .querySelectorAll("[class^='euiHeader']")
+        .forEach((e) => e.remove());
+      document.body.style.paddingTop = '0px';
+    }
   );
   // force wait for any resize to load after the above DOM modification
   await page.waitFor(1000);


### PR DESCRIPTION
*Issue #, if available:*

The current DOM element selector we use is not generic enough, so it may lead to more manual work during each version compatibility check. Some html element of Kibana dashboard with minor update will easily break the report creation logic.

*Description of changes:*
Instead of using a specific class/id selector of a specific element in a specific kibana version, I tried to come up with a generic selector while we operate the DOM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
