### PR TITLE
Definition Details Modal & Delete Toast 

### DIFF
--- a/kibana-reports/.cypress/integration/04-download.spec.ts
+++ b/kibana-reports/.cypress/integration/04-download.spec.ts
@@ -80,4 +80,38 @@ describe('Cypress', () => {
 
     cy.get('#generateCSV').click({ force: true });
   });
+
+  it('Download from Report definition details page', () => {
+    // create an on-demand report definition 
+
+    cy.visit('http://localhost:5601/app/opendistro_kibana_reports#/');
+    cy.location('pathname', { timeout: 60000 }).should(
+      'include',
+      '/opendistro_kibana_reports'
+    );
+    cy.wait(12500);
+    cy.get('#createReportHomepageButton').click();
+
+    // enter a report name
+    cy.get('#reportSettingsName').type('Create cypress test on-demand report');
+
+    // enter a report description
+    cy.get('#reportSettingsDescription').type('Description for cypress test');
+
+    // create an on-demand report definition
+    cy.get('#createNewReportDefinition').click({ force: true });
+
+    cy.wait(5000);
+
+    // visit the details page of the newly created on-demand definition
+    cy.get('#reportDefinitionDetailsLink').first().click();
+
+    cy.url().should('include', 'report_definition_details');
+
+    cy.get('#generateReportFromDetailsButton').should('exist');
+
+    cy.get('#generateReportFromDetailsButton').click({ force: true });
+
+    cy.get('#downloadInProgressLoadingModal');
+  });
 });

--- a/kibana-reports/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
+++ b/kibana-reports/public/components/main/__tests__/__snapshots__/main.test.tsx.snap
@@ -1871,6 +1871,997 @@ exports[`<Main /> panel render component after create success 1`] = `
 </div>
 `;
 
+exports[`<Main /> panel render component after delete success 1`] = `
+<div>
+  <div
+    class="euiPanel euiPanel--paddingLarge"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceEvenly euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <h2
+          class="euiTitle euiTitle--medium"
+        >
+          Reports
+           
+          <p
+            style="color: gray; display: inline;"
+          >
+             (
+            0
+            )
+          </p>
+        </h2>
+      </div>
+      <span
+        class="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          class="euiButton euiButton--primary"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButton__content"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.228 2.942a.5.5 0 11-.538.842A5 5 0 1013 8a.5.5 0 111 0 6 6 0 11-2.772-5.058zM14 1.5v3A1.5 1.5 0 0112.5 6h-3a.5.5 0 010-1h3a.5.5 0 00.5-.5v-3a.5.5 0 111 0z"
+              />
+            </svg>
+            <span
+              class="euiButton__text"
+            >
+              Refresh
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+    <hr
+      class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginLarge"
+    />
+    <div>
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+      >
+        <div
+          class="euiFlexItem euiSearchBar__searchHolder"
+        >
+          <div
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          >
+            <div
+              class="euiFormControlLayout__childrenWrapper"
+            >
+              <input
+                aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+                placeholder="Search..."
+                type="search"
+                value=""
+              />
+              <div
+                class="euiFormControlLayoutIcons"
+              >
+                <span
+                  class="euiFormControlLayoutCustomIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
+        >
+          <div
+            class="euiFilterGroup"
+          >
+            <div
+              class="euiPopover euiPopover--anchorDownCenter"
+              id="field_value_selection_0"
+            >
+              <div
+                class="euiPopover__anchor"
+              >
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                  type="button"
+                >
+                  <span
+                    class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--medium euiButtonContent__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                        fill-rule="non-zero"
+                      />
+                    </svg>
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      <span
+                        class="euiFilterButton__textShift"
+                        data-text="Type"
+                        title="Type"
+                      >
+                        Type
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="euiPopover euiPopover--anchorDownCenter"
+              id="field_value_selection_1"
+            >
+              <div
+                class="euiPopover__anchor"
+              >
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
+                  type="button"
+                >
+                  <span
+                    class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--medium euiButtonContent__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                        fill-rule="non-zero"
+                      />
+                    </svg>
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      <span
+                        class="euiFilterButton__textShift"
+                        data-text="State"
+                        title="State"
+                      >
+                        State
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiBasicTable"
+      >
+        <div>
+          <div
+            class="euiTableHeaderMobile"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+            >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              />
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <div
+                  class="euiTableSortMobile"
+                >
+                  <div
+                    class="euiPopover euiPopover--anchorDownRight"
+                  >
+                    <div
+                      class="euiPopover__anchor"
+                    >
+                      <button
+                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                        type="button"
+                      >
+                        <span
+                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiButtonContent__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                              fill-rule="non-zero"
+                            />
+                          </svg>
+                          <span
+                            class="euiButtonEmpty__text"
+                          >
+                            Sorting
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <table
+            class="euiTable euiTable--responsive euiTable--auto"
+            id="random_html_id"
+            tabindex="-1"
+          >
+            <caption
+              class="euiScreenReaderOnly euiTableCaption"
+            />
+            <thead>
+              <tr>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_reportName_0"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Name"
+                    >
+                      Name
+                    </span>
+                  </div>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_reportSource_1"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Source"
+                    >
+                      Source
+                    </span>
+                  </div>
+                </th>
+                <th
+                  aria-live="polite"
+                  aria-sort="none"
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_type_2"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    class="euiTableHeaderButton"
+                    data-test-subj="tableHeaderSortButton"
+                    type="button"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Type"
+                      >
+                        Type
+                      </span>
+                      <span
+                        class="euiScreenReaderOnly"
+                      >
+                        Click to sort in ascending order
+                      </span>
+                    </span>
+                  </button>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_timeCreated_3"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Creation time"
+                    >
+                      Creation time
+                    </span>
+                  </div>
+                </th>
+                <th
+                  aria-live="polite"
+                  aria-sort="none"
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_state_4"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <button
+                    class="euiTableHeaderButton"
+                    data-test-subj="tableHeaderSortButton"
+                    type="button"
+                  >
+                    <span
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="State"
+                      >
+                        State
+                      </span>
+                      <span
+                        class="euiScreenReaderOnly"
+                      >
+                        Click to sort in ascending order
+                      </span>
+                    </span>
+                  </button>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_id_5"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Generate"
+                    >
+                      Generate
+                    </span>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="euiTableRow"
+              >
+                <td
+                  class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                  colspan="6"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignCenter"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      <div
+                        class="euiEmptyPrompt"
+                      >
+                        <span
+                          class="euiTextColor euiTextColor--subdued"
+                        >
+                          <h3
+                            class="euiTitle euiTitle--xsmall"
+                          >
+                            No reports to display
+                          </h3>
+                          <div
+                            class="euiSpacer euiSpacer--m"
+                          />
+                          <div
+                            class="euiText euiText--medium"
+                          >
+                            <div>
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                Create a report definition, or share/download a report from a dashboard, saved search or visualization.
+                              </div>
+                              <div
+                                class="euiText euiText--medium"
+                              >
+                                To learn more, see
+                                 
+                                <a
+                                  class="euiLink euiLink--primary"
+                                  href="https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/reporting/"
+                                  rel="noopener noreferrer"
+                                  target="_blank"
+                                >
+                                  Get started with Kibana reporting 
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--medium"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                                    />
+                                  </svg>
+                                </a>
+                              </div>
+                            </div>
+                          </div>
+                        </span>
+                      </div>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiSpacer euiSpacer--l"
+  />
+  <div
+    class="euiPanel euiPanel--paddingLarge"
+  >
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--justifyContentSpaceEvenly euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem"
+      >
+        <h2
+          class="euiTitle euiTitle--medium"
+        >
+          Report definitions
+          <p
+            style="color: gray; display: inline;"
+          >
+             
+            (
+            0
+            )
+          </p>
+        </h2>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          class="euiButton euiButton--primary"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButton__content"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiButtonContent__icon"
+              focusable="false"
+              height="16"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.228 2.942a.5.5 0 11-.538.842A5 5 0 1013 8a.5.5 0 111 0 6 6 0 11-2.772-5.058zM14 1.5v3A1.5 1.5 0 0112.5 6h-3a.5.5 0 010-1h3a.5.5 0 00.5-.5v-3a.5.5 0 111 0z"
+              />
+            </svg>
+            <span
+              class="euiButton__text"
+            >
+              Refresh
+            </span>
+          </span>
+        </button>
+      </div>
+      <span
+        class="euiFlexItem euiFlexItem--flexGrowZero"
+      >
+        <button
+          class="euiButton euiButton--primary euiButton--fill"
+          id="createReportHomepageButton"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButton__content"
+          >
+            <span
+              class="euiButton__text"
+            >
+              Create
+            </span>
+          </span>
+        </button>
+      </span>
+    </div>
+    <hr
+      class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginLarge"
+    />
+    <div>
+      <div>
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
+        >
+          <div
+            class="euiFlexItem euiSearchBar__searchHolder"
+          >
+            <div
+              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper"
+              >
+                <input
+                  aria-label="This is a search bar. As you type, the results lower in the page will automatically filter."
+                  class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
+                  placeholder="Search..."
+                  type="search"
+                  value=""
+                />
+                <div
+                  class="euiFormControlLayoutIcons"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
+          >
+            <div
+              class="euiFilterGroup"
+            />
+          </div>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiBasicTable"
+        >
+          <div>
+            <div
+              class="euiTableHeaderMobile"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+              >
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                />
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <div
+                    class="euiTableSortMobile"
+                  >
+                    <div
+                      class="euiPopover euiPopover--anchorDownRight"
+                    >
+                      <div
+                        class="euiPopover__anchor"
+                      >
+                        <button
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiButtonEmpty--flushRight"
+                          type="button"
+                        >
+                          <span
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
+                              />
+                            </svg>
+                            <span
+                              class="euiButtonEmpty__text"
+                            >
+                              Sorting
+                            </span>
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <table
+              class="euiTable euiTable--responsive euiTable--auto"
+              id="random_html_id"
+              tabindex="-1"
+            >
+              <caption
+                class="euiScreenReaderOnly euiTableCaption"
+              />
+              <thead>
+                <tr>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_reportName_0"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Name"
+                      >
+                        Name
+                      </span>
+                    </div>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_source_1"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Source"
+                      >
+                        Source
+                      </span>
+                    </div>
+                  </th>
+                  <th
+                    aria-live="polite"
+                    aria-sort="none"
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_type_2"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <button
+                      class="euiTableHeaderButton"
+                      data-test-subj="tableHeaderSortButton"
+                      type="button"
+                    >
+                      <span
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                          title="Type"
+                        >
+                          Type
+                        </span>
+                        <span
+                          class="euiScreenReaderOnly"
+                        >
+                          Click to sort in ascending order
+                        </span>
+                      </span>
+                    </button>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_details_3"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Schedule details"
+                      >
+                        Schedule details
+                      </span>
+                    </div>
+                  </th>
+                  <th
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_lastUpdated_4"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <div
+                      class="euiTableCellContent"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Last Updated"
+                      >
+                        Last Updated
+                      </span>
+                    </div>
+                  </th>
+                  <th
+                    aria-live="polite"
+                    aria-sort="none"
+                    class="euiTableHeaderCell"
+                    data-test-subj="tableHeaderCell_status_5"
+                    role="columnheader"
+                    scope="col"
+                  >
+                    <button
+                      class="euiTableHeaderButton"
+                      data-test-subj="tableHeaderSortButton"
+                      type="button"
+                    >
+                      <span
+                        class="euiTableCellContent"
+                      >
+                        <span
+                          class="euiTableCellContent__text"
+                          title="Status"
+                        >
+                          Status
+                        </span>
+                        <span
+                          class="euiScreenReaderOnly"
+                        >
+                          Click to sort in ascending order
+                        </span>
+                      </span>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  class="euiTableRow"
+                >
+                  <td
+                    class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
+                    colspan="6"
+                  >
+                    <div
+                      class="euiTableCellContent euiTableCellContent--alignCenter"
+                    >
+                      <span
+                        class="euiTableCellContent__text"
+                      >
+                        <div
+                          class="euiEmptyPrompt"
+                        >
+                          <span
+                            class="euiTextColor euiTextColor--subdued"
+                          >
+                            <h3
+                              class="euiTitle euiTitle--xsmall"
+                            >
+                              No report definitions to display
+                            </h3>
+                            <div
+                              class="euiSpacer euiSpacer--m"
+                            />
+                            <div
+                              class="euiText euiText--medium"
+                            >
+                              <div>
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  Create a new report definition to get started
+                                </div>
+                                <div
+                                  class="euiText euiText--medium"
+                                >
+                                  To learn more, see
+                                   
+                                  <a
+                                    class="euiLink euiLink--primary"
+                                    href="https://opendistro.github.io/for-elasticsearch-docs/docs/kibana/reporting/"
+                                    rel="noopener noreferrer"
+                                    target="_blank"
+                                  >
+                                    Get started with Kibana reporting 
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
+                                      />
+                                    </svg>
+                                  </a>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                          <div
+                            class="euiSpacer euiSpacer--l"
+                          />
+                          <div
+                            class="euiSpacer euiSpacer--s"
+                          />
+                          <div>
+                            <button
+                              class="euiButton euiButton--primary"
+                              type="button"
+                            >
+                              <span
+                                class="euiButtonContent euiButton__content"
+                              >
+                                <span
+                                  class="euiButton__text"
+                                >
+                                  Create report definition
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                        </div>
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-live="polite"
+    class="euiGlobalToastList euiGlobalToastList--right"
+    role="region"
+  >
+    <div
+      class="euiToast euiToast--success euiGlobalToastListItem"
+      id="deleteReportDefinitionSuccessToast"
+    >
+      <p
+        class="euiScreenReaderOnly"
+      >
+        A new notification appears
+      </p>
+      <div
+        aria-label="Notification"
+        class="euiToastHeader"
+        data-test-subj="euiToastHeader"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium euiToastHeader__icon"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6.5 12a.502.502 0 01-.354-.146l-4-4a.502.502 0 01.708-.708L6.5 10.793l6.646-6.647a.502.502 0 01.708.708l-7 7A.502.502 0 016.5 12"
+            fill-rule="evenodd"
+          />
+        </svg>
+        <span
+          class="euiToastHeader__title"
+        >
+          Successfully deleted report definition.
+        </span>
+      </div>
+      <button
+        aria-label="Dismiss toast"
+        class="euiToast__closeButton"
+        data-test-subj="toastCloseButton"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="euiIcon euiIcon--medium"
+          focusable="false"
+          height="16"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Main /> panel render component after edit success 1`] = `
 <div>
   <div

--- a/kibana-reports/public/components/main/__tests__/main.test.tsx
+++ b/kibana-reports/public/components/main/__tests__/main.test.tsx
@@ -81,6 +81,24 @@ describe('<Main /> panel', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('render component after delete success', async () => {
+    delete window.location; 
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        assign: jest.fn(),
+        href: 'opendistro_kibana_reports#/delete=success',
+      },
+    });
+
+    const { container } = render(
+      <Main httpClient={httpClientMock} setBreadcrumbs={setBreadcrumbs} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  })
+
   test('test refresh reports definitions button', async () => {
     const promise = Promise.resolve();
     const data = [

--- a/kibana-reports/public/components/main/main.tsx
+++ b/kibana-reports/public/components/main/main.tsx
@@ -159,6 +159,20 @@ export function Main(props) {
     addEditReportDefinitionSuccessToastHandler();
   };
 
+  const addDeleteReportDefinitionSuccessToastHandler = () => {
+    const successToast = {
+      title: 'Successfully deleted report definition.',
+      color: 'success',
+      iconType: 'check',
+      id: 'deleteReportDefinitionSuccessToast'
+    };
+    setToasts(toasts.concat(successToast));
+  }
+
+  const handleDeleteReportDefinitionSuccessToast = () => {
+    addDeleteReportDefinitionSuccessToastHandler();
+  }
+
   const removeToast = (removedToast) => {
     setToasts(toasts.filter((toast) => toast.id !== removedToast.id));
   };
@@ -188,6 +202,12 @@ export function Main(props) {
       }, 1000);
     } else if (window.location.href.includes('edit=success')) {
       handleEditReportDefinitionSuccessToast();
+      setTimeout(() => {
+        refreshReportsTable();
+        refreshReportsDefinitionsTable();
+      }, 1000);
+    } else if (window.location.href.includes('delete=success')) {
+      handleDeleteReportDefinitionSuccessToast();
       setTimeout(() => {
         refreshReportsTable();
         refreshReportsDefinitionsTable();

--- a/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
+++ b/kibana-reports/public/components/main/report_definition_details/report_definition_details.tsx
@@ -476,10 +476,12 @@ export function ReportDefinitionDetails(props) {
 
   const generateReportFromDetails = async () => {
     const { httpClient } = props;
+    handleLoading(true);
     let generateReportSuccess = await generateReportFromDefinitionId(
       reportDefinitionId,
       httpClient
     );
+    handleLoading(false);
     if (generateReportSuccess.status) {
       handleSuccessGeneratingReportToast();
     } else {
@@ -496,7 +498,7 @@ export function ReportDefinitionDetails(props) {
     httpClient
       .delete(`../api/reporting/reportDefinitions/${reportDefinitionId}`)
       .then(() => {
-        window.location.assign(`opendistro_kibana_reports#/`);
+        window.location.assign(`opendistro_kibana_reports#/delete=success`);
       })
       .catch((error) => {
         console.log('error when deleting report definition:', error);


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Added loading modal for `Generate report` button in on-demand Report definition details page, and successful delete toast for deleting a report definition. 

![Screen Shot 2020-12-16 at 12 32 54 PM](https://user-images.githubusercontent.com/53581635/102404266-4b8e5800-3f9c-11eb-9711-801cf7c98fe6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
