### PR TITLE
Configure Max Size for Dashboards API & Minor UI Changes

### DIFF
--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
@@ -1055,9 +1055,6 @@ exports[`<ReportSettings /> panel dashboard create from in-context 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -2124,9 +2121,6 @@ exports[`<ReportSettings /> panel display errors on create 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -2609,9 +2603,6 @@ exports[`<ReportSettings /> panel render component 1`] = `
         />
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -3112,9 +3103,6 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
         />
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -3615,9 +3603,6 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
         />
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -4118,9 +4103,6 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
         />
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -5180,9 +5162,6 @@ exports[`<ReportSettings /> panel saved search create from in-context 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;
@@ -6242,9 +6221,6 @@ exports[`<ReportSettings /> panel visualization create from in-context 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
   </div>
 </div>
 `;

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -689,7 +689,6 @@ export function ReportSettings(props: ReportSettingProps) {
         />
         <EuiSpacer />
         {displayVisualReportsFormatAndMarkdown}
-        <EuiSpacer />
       </EuiPageContentBody>
     </EuiPageContent>
   );

--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -479,7 +479,7 @@ export function ReportTrigger(props: ReportTriggerProps) {
           error={'Invalid cron expression.'}
           labelAppend={
             <EuiText size="xs">
-              <EuiLink href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/cron/" target="_blank">
+              <EuiLink href="https://opendistro.github.io/for-elasticsearch-docs/docs/alerting/cron/" target="_blank" external={true}>
                 Cron help
               </EuiLink>
             </EuiText>

--- a/kibana-reports/server/routes/reportSource.ts
+++ b/kibana-reports/server/routes/reportSource.ts
@@ -44,6 +44,7 @@ export default function (router: IRouter) {
         const params: RequestParams.Search = {
           index: '.kibana',
           q: 'type:dashboard',
+          size: DEFAULT_MAX_SIZE,
         };
         responseParams = params;
       } else if (request.params.reportSourceType === 'visualization') {


### PR DESCRIPTION
*Issue #, if available:*
#264 
*Description of changes:*
* Configured size of dashboard API to remove dashboard default limit of 10. Now it is set to `DEFAULT_MAX_SIZE` constant which is 10000. 
* Added external icon to `cron help` link in `Report trigger` 
* Removed extra `EuiSpacer` in Report settings to correct spacing 
* Updated snapshots 

![Screen Shot 2020-12-18 at 11 37 44 AM](https://user-images.githubusercontent.com/53581635/102656457-c1272f00-4128-11eb-82f4-e19a20287b60.png)

![Screen Shot 2020-12-18 at 11 52 07 AM](https://user-images.githubusercontent.com/53581635/102656466-c4bab600-4128-11eb-908d-7b6d1a9e9859.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
