### PR TITLE
[Bug fix] support csv report for saved search with multiple indices

### DIFF
--- a/kibana-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/kibana-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../../../src/core/server';
 import { getFileName, callCluster } from './helpers';
 import { CreateReportResultType } from './types';
+import { DEFAULT_MAX_SIZE } from './constants';
 
 /**
  * Specify how long scroll context should be maintained for scrolled search
@@ -159,10 +160,17 @@ async function generateReportData(
       },
       isScheduledTask
     );
-    // The location of max result window differs if default overridden.
-    return settings[indexPattern].settings.index.max_result_window != null
-      ? settings[indexPattern].settings.index.max_result_window
-      : settings[indexPattern].defaults.index.max_result_window;
+
+    let maxResultSize = Number.MAX_SAFE_INTEGER;
+    for (let indexName in settings) {
+      // The location of max result window differs if default overridden.
+      maxResultSize = Math.min(
+        maxResultSize,
+        settings[indexName].settings.index.max_result_window ||
+          settings[indexName].defaults.index.max_result_window
+      );
+    }
+    return maxResultSize;
   }
 
   // Build the ES Count query to count the size of result

--- a/kibana-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/kibana-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -26,7 +26,6 @@ import {
 } from '../../../../../src/core/server';
 import { getFileName, callCluster } from './helpers';
 import { CreateReportResultType } from './types';
-import { DEFAULT_MAX_SIZE } from './constants';
 
 /**
  * Specify how long scroll context should be maintained for scrolled search


### PR DESCRIPTION
*Issue #, if available:*
#262 #251 #249

*Description of changes:*
- Add the traverse logic to find the correct value for `maxResultSize`, for saved search settings with multiple indices.(usually from index-pattern using wildcard)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
