### PR TITLE
Add flag to chromium to use single process

### DIFF
--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -66,7 +66,7 @@ export const createVisualReport = async (
      * TODO: temp fix to disable sandbox when launching chromium on Linux instance
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--no-zygote', '--single-process'],
     executablePath: CHROMIUM_PATH,
     env: {
       TZ: timezone || 'UTC',


### PR DESCRIPTION
*Issue #, if available:*
 #265 

*Description of changes:*
- Add `'--no-zygote', '--single-process'` flags when Puppeteer launches chromium to reduce number of processes and memory usage

Did some testing on MacOS, Windows, Amazon Linux 2, Ubuntu and didn't find side effects

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
