### PR TITLE
Add integration test cases for report definition rest APIs

### DIFF
--- a/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/TestHelpers.kt
+++ b/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/TestHelpers.kt
@@ -22,6 +22,46 @@ import org.junit.Assert
 import java.time.Instant
 import kotlin.test.assertTrue
 
+fun constructReportDefinitionRequest(
+    trigger: String = """
+            "trigger":{
+                "triggerType":"OnDemand"
+            },
+        """.trimIndent(),
+    name: String = "report_definition"
+): String {
+    return """
+            {
+                "reportDefinition":{
+                    "name":"$name",
+                    "isEnabled":true,
+                    "source":{
+                        "description":"description",
+                        "type":"Dashboard",
+                        "origin":"localhost:5601",
+                        "id":"id"
+                    },
+                    "format":{
+                        "duration":"PT1H",
+                        "fileFormat":"Pdf",
+                        "limit":1000,
+                        "header":"optional header",
+                        "footer":"optional footer"
+                    },
+                    $trigger
+                    "delivery":{
+                        "recipients":["nobody@email.com"],
+                        "deliveryFormat":"LinkOnly",
+                        "title":"title",
+                        "textDescription":"textDescription",
+                        "htmlDescription":"optional htmlDescription",
+                        "channelIds":["optional_channelIds"]
+                    }
+                }
+            }
+            """.trimIndent()
+}
+
 fun jsonify(text: String): JsonObject {
     return JsonParser.parseString(text).asJsonObject
 }

--- a/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/TestHelpers.kt
+++ b/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/TestHelpers.kt
@@ -35,7 +35,7 @@ fun validateTimeRecency(time: Instant, accuracySeconds: Long) {
     validateTimeNearRefTime(time, Instant.now(), accuracySeconds)
 }
 
-fun validateErrorResponse(response: JsonObject, statusCode: Int) {
+fun validateErrorResponse(response: JsonObject, statusCode: Int, errorType: String = "status_exception") {
     Assert.assertNotNull("Error response content should be generated", response)
     val status = response.get("status").asInt
     val error = response.get("error").asJsonObject
@@ -43,7 +43,7 @@ fun validateErrorResponse(response: JsonObject, statusCode: Int) {
     val type = error.get("type").asString
     val reason = error.get("reason").asString
     Assert.assertEquals(statusCode, status)
-    Assert.assertEquals("status_exception", type)
+    Assert.assertEquals(errorType, type)
     Assert.assertNotNull(reason)
     Assert.assertNotNull(rootCause)
     Assert.assertTrue(rootCause.size() > 0)

--- a/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
+++ b/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
@@ -64,32 +64,32 @@ class ReportDefinitionIT : PluginRestTestCase() {
     }
 
     fun `test create, get, update, delete report definition`() {
-        var reportDefinitionRequest = constructReportDefinitionRequest()
-        var reportDefinitionResponse = executeRequest(
+        val reportDefinitionOnDemandRequest = constructReportDefinitionRequest()
+        val reportDefinitionOnDemandResponse = executeRequest(
             RestRequest.Method.POST.name,
             "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
+            reportDefinitionOnDemandRequest,
             RestStatus.OK.status
         )
-        var reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
-        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
+        val reportDefinitionOnDemandId = reportDefinitionOnDemandResponse.get("reportDefinitionId").asString
+        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionOnDemandId)
         Thread.sleep(100)
 
-        reportDefinitionRequest = constructReportDefinitionRequest(
+        val reportDefinitionDownloadRequest = constructReportDefinitionRequest(
             """
                 "trigger":{
                     "triggerType":"Download"
                 },
             """.trimIndent()
         )
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionDownloadResponse = executeRequest(
             RestRequest.Method.POST.name,
             "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
+            reportDefinitionDownloadRequest,
             RestStatus.OK.status
         )
-        reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
-        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
+        val reportDefinitionDownloadId = reportDefinitionDownloadResponse.get("reportDefinitionId").asString
+        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionDownloadId)
         Thread.sleep(1000)
 
         val reportDefinitionsResponse = executeRequest(
@@ -102,76 +102,82 @@ class ReportDefinitionIT : PluginRestTestCase() {
         Thread.sleep(100)
 
         val newName = "updated_report"
-        reportDefinitionRequest = constructReportDefinitionRequest(name = newName)
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionUpdateRequest = constructReportDefinitionRequest(name = newName)
+        val reportDefinitionUpdateResponse = executeRequest(
             RestRequest.Method.PUT.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionId",
-            reportDefinitionRequest,
+            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
+            reportDefinitionUpdateRequest,
             RestStatus.OK.status
         )
-        Assert.assertEquals(reportDefinitionId, reportDefinitionResponse.get("reportDefinitionId").asString)
+        Assert.assertEquals(
+            reportDefinitionOnDemandId,
+            reportDefinitionUpdateResponse.get("reportDefinitionId").asString
+        )
         Thread.sleep(100)
 
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionGetResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionId",
+            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
             "",
             RestStatus.OK.status
         )
         Assert.assertEquals(
-            reportDefinitionId,
-            reportDefinitionResponse.get("reportDefinitionDetails").asJsonObject.get("id").asString
+            reportDefinitionOnDemandId,
+            reportDefinitionGetResponse.get("reportDefinitionDetails").asJsonObject.get("id").asString
         )
         Assert.assertEquals(
             newName,
-            reportDefinitionResponse.get("reportDefinitionDetails").asJsonObject
+            reportDefinitionGetResponse.get("reportDefinitionDetails").asJsonObject
                 .get("reportDefinition").asJsonObject.get("name").asString
         )
         Thread.sleep(100)
 
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionDeleteResponse = executeRequest(
             RestRequest.Method.DELETE.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionId",
+            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
             "",
             RestStatus.OK.status
         )
-        Assert.assertEquals(reportDefinitionId, reportDefinitionResponse.get("reportDefinitionId").asString)
+        Assert.assertEquals(
+            reportDefinitionOnDemandId,
+            reportDefinitionDeleteResponse.get("reportDefinitionId").asString
+        )
         Thread.sleep(100)
 
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionGetNotFoundResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$BASE_REPORTS_URI/definition/$reportDefinitionId",
+            "$BASE_REPORTS_URI/definition/$reportDefinitionOnDemandId",
             "",
             RestStatus.NOT_FOUND.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.NOT_FOUND.status)
+        validateErrorResponse(reportDefinitionGetNotFoundResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionInvalidGetResponse = executeRequest(
             RestRequest.Method.GET.name,
             "$BASE_REPORTS_URI/definition/invalid-id",
             "",
             RestStatus.NOT_FOUND.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.NOT_FOUND.status)
+        validateErrorResponse(reportDefinitionInvalidGetResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionInvalidUpdateResponse = executeRequest(
             RestRequest.Method.PUT.name,
             "$BASE_REPORTS_URI/definition/invalid-id",
             constructReportDefinitionRequest(),
             RestStatus.NOT_FOUND.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.NOT_FOUND.status)
+        validateErrorResponse(reportDefinitionInvalidUpdateResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
 
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionInvalidDeleteResponse = executeRequest(
             RestRequest.Method.DELETE.name,
             "$BASE_REPORTS_URI/definition/invalid-id",
             "",
             RestStatus.NOT_FOUND.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.NOT_FOUND.status)
+        validateErrorResponse(reportDefinitionInvalidDeleteResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
     }
 
@@ -225,22 +231,22 @@ class ReportDefinitionIT : PluginRestTestCase() {
     }
 
     fun `test create invalid cron scheduled report definition`() {
-        var trigger = """
+        val cronTrigger = """
             "trigger":{
                 "triggerType":"CronSchedule"
             },
         """.trimIndent()
-        var reportDefinitionRequest = constructReportDefinitionRequest(trigger)
-        var reportDefinitionResponse = executeRequest(
+        val reportDefinitionCronRequest = constructReportDefinitionRequest(cronTrigger)
+        val reportDefinitionCronResponse = executeRequest(
             RestRequest.Method.POST.name,
             "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
+            reportDefinitionCronRequest,
             RestStatus.BAD_REQUEST.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
+        validateErrorResponse(reportDefinitionCronResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
         Thread.sleep(100)
 
-        trigger = """
+        val invalidCronTrigger = """
             "trigger":{
                 "triggerType":"CronSchedule",
                 "schedule":{
@@ -251,34 +257,42 @@ class ReportDefinitionIT : PluginRestTestCase() {
                 }
             },
         """.trimIndent()
-        reportDefinitionRequest = constructReportDefinitionRequest(trigger)
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionInvalidCronRequest = constructReportDefinitionRequest(invalidCronTrigger)
+        val reportDefinitionInvalidCronResponse = executeRequest(
             RestRequest.Method.POST.name,
             "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
+            reportDefinitionInvalidCronRequest,
             RestStatus.BAD_REQUEST.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
+        validateErrorResponse(
+            reportDefinitionInvalidCronResponse,
+            RestStatus.BAD_REQUEST.status,
+            "illegal_argument_exception"
+        )
         Thread.sleep(100)
     }
 
     fun `test create invalid interval scheduled report definition`() {
-        var trigger = """
+        val intervalTrigger = """
             "trigger":{
                 "triggerType":"IntervalSchedule"
             },
         """.trimIndent()
-        var reportDefinitionRequest = constructReportDefinitionRequest(trigger)
-        var reportDefinitionResponse = executeRequest(
+        val reportDefinitionIntervalRequest = constructReportDefinitionRequest(intervalTrigger)
+        val reportDefinitionIntervalResponse = executeRequest(
             RestRequest.Method.POST.name,
             "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
+            reportDefinitionIntervalRequest,
             RestStatus.BAD_REQUEST.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
+        validateErrorResponse(
+            reportDefinitionIntervalResponse,
+            RestStatus.BAD_REQUEST.status,
+            "illegal_argument_exception"
+        )
         Thread.sleep(100)
 
-        trigger = """
+        val invalidIntervalTrigger = """
             "trigger":{
                 "triggerType":"IntervalSchedule",
                 "schedule":{
@@ -287,14 +301,18 @@ class ReportDefinitionIT : PluginRestTestCase() {
                 }
             },
         """.trimIndent()
-        reportDefinitionRequest = constructReportDefinitionRequest(trigger)
-        reportDefinitionResponse = executeRequest(
+        val reportDefinitionInvalidIntervalRequest = constructReportDefinitionRequest(invalidIntervalTrigger)
+        val reportDefinitionInvalidIntervalResponse = executeRequest(
             RestRequest.Method.POST.name,
             "$BASE_REPORTS_URI/definition",
-            reportDefinitionRequest,
+            reportDefinitionInvalidIntervalRequest,
             RestStatus.BAD_REQUEST.status
         )
-        validateErrorResponse(reportDefinitionResponse, RestStatus.BAD_REQUEST.status, "illegal_argument_exception")
+        validateErrorResponse(
+            reportDefinitionInvalidIntervalResponse,
+            RestStatus.BAD_REQUEST.status,
+            "illegal_argument_exception"
+        )
         Thread.sleep(100)
     }
 }

--- a/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
+++ b/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
@@ -51,7 +51,7 @@ class ReportDefinitionIT : PluginRestTestCase() {
                     },
                     $trigger
                     "delivery":{
-                        "recipients":["banantha@amazon.com"],
+                        "recipients":["nobody@email.com"],
                         "deliveryFormat":"LinkOnly",
                         "title":"title",
                         "textDescription":"textDescription",
@@ -90,7 +90,7 @@ class ReportDefinitionIT : PluginRestTestCase() {
         )
         reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
         Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
-        Thread.sleep(3000)
+        Thread.sleep(1000)
 
         val reportDefinitionsResponse = executeRequest(
             RestRequest.Method.GET.name,
@@ -124,9 +124,8 @@ class ReportDefinitionIT : PluginRestTestCase() {
         )
         Assert.assertEquals(
             newName,
-            reportDefinitionResponse.get("reportDefinitionDetails").asJsonObject.get("reportDefinition").asJsonObject.get(
-                "name"
-            ).asString
+            reportDefinitionResponse.get("reportDefinitionDetails").asJsonObject
+                .get("reportDefinition").asJsonObject.get("name").asString
         )
         Thread.sleep(100)
 
@@ -147,10 +146,8 @@ class ReportDefinitionIT : PluginRestTestCase() {
         )
         validateErrorResponse(reportDefinitionResponse, RestStatus.NOT_FOUND.status)
         Thread.sleep(100)
-    }
 
-    fun `test invalid get, update, delete report definition`() {
-        var reportDefinitionResponse = executeRequest(
+        reportDefinitionResponse = executeRequest(
             RestRequest.Method.GET.name,
             "$BASE_REPORTS_URI/definition/invalid-id",
             "",

--- a/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
+++ b/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
@@ -1,0 +1,186 @@
+package com.amazon.opendistroforelasticsearch.reportsscheduler.rest
+
+import com.amazon.opendistroforelasticsearch.reportsscheduler.PluginRestTestCase
+import com.amazon.opendistroforelasticsearch.reportsscheduler.ReportsSchedulerPlugin.Companion.BASE_REPORTS_URI
+import org.elasticsearch.rest.RestRequest
+import org.junit.Assert
+
+class ReportDefinitionIT : PluginRestTestCase() {
+    private fun constructReportDefinitionRequest(
+        trigger: String,
+        type: String = "Dashboard",
+        origin: String = "localhost:5601"
+    ): String {
+        return """
+            {
+                "reportDefinition":{
+                    "name":"report_definition",
+                    "isEnabled":true,
+                    "source":{
+                        "description":"description",
+                        "type":"$type",
+                        "origin":"$origin",
+                        "id":"id"
+                    },
+                    "format":{
+                        "duration":"PT1H",
+                        "fileFormat":"Pdf",
+                        "limit":1000,
+                        "header":"optional header",
+                        "footer":"optional footer"
+                    },
+                    $trigger
+                    "delivery":{
+                        "recipients":["banantha@amazon.com"],
+                        "deliveryFormat":"LinkOnly",
+                        "title":"title",
+                        "textDescription":"textDescription",
+                        "htmlDescription":"optional htmlDescription",
+                        "channelIds":["optional_channelIds"]
+                    }
+                }
+            }
+            """.trimIndent()
+    }
+
+    fun `test create and get on-demand report definition`() {
+        val trigger = """
+            "trigger":{
+                "triggerType":"OnDemand"
+            },
+        """.trimIndent()
+        val createReportDefinitionRequest = constructReportDefinitionRequest(trigger)
+        val createReportDefinitionResponse = executeRequest(
+            RestRequest.Method.POST.name,
+            "$BASE_REPORTS_URI/definition",
+            createReportDefinitionRequest,
+            200
+        )
+        val reportDefinitionId = createReportDefinitionResponse.get("reportDefinitionId").asString
+        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
+        Thread.sleep(100)
+
+        val getReportDefinitionResponse = executeRequest(
+            RestRequest.Method.GET.name,
+            "$BASE_REPORTS_URI/definition/$reportDefinitionId",
+            "",
+            200
+        )
+        Assert.assertEquals(
+            reportDefinitionId,
+            getReportDefinitionResponse.get("reportDefinitionDetails").asJsonObject.get("id").asString
+        )
+        Thread.sleep(100)
+    }
+
+    fun `test create download report definition`() {
+        val trigger = """
+            "trigger":{
+                "triggerType":"Download"
+            },
+        """.trimIndent()
+        val reportDefinitionRequest = constructReportDefinitionRequest(trigger)
+        val reportDefinitionResponse = executeRequest(
+            RestRequest.Method.POST.name,
+            "$BASE_REPORTS_URI/definition",
+            reportDefinitionRequest,
+            200
+        )
+        val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
+        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
+        Thread.sleep(100)
+    }
+
+    fun `test create cron scheduled report definition`() {
+        val trigger = """
+            "trigger":{
+                "triggerType":"CronSchedule",
+                "schedule":{
+                    "cron":{
+                        "expression":"0 * * * *",
+                        "timezone":"America/Los_Angeles"
+                    }
+                }
+            },
+        """.trimIndent()
+        val reportDefinitionRequest = constructReportDefinitionRequest(trigger)
+        val reportDefinitionResponse = executeRequest(
+            RestRequest.Method.POST.name,
+            "$BASE_REPORTS_URI/definition",
+            reportDefinitionRequest,
+            200
+        )
+        val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
+        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
+        Thread.sleep(100)
+    }
+
+    fun `test create interval scheduled report definition`() {
+        val trigger = """
+            "trigger":{
+                "triggerType":"IntervalSchedule",
+                "schedule":{
+                    "interval":{
+                        "start_time":1603506908773,
+                        "period":"10",
+                        "unit":"Minutes"
+                    }
+                }
+            },
+        """.trimIndent()
+        val reportDefinitionRequest = constructReportDefinitionRequest(trigger)
+        val reportDefinitionResponse = executeRequest(
+            RestRequest.Method.POST.name,
+            "$BASE_REPORTS_URI/definition",
+            reportDefinitionRequest,
+            200
+        )
+        val reportDefinitionId = reportDefinitionResponse.get("reportDefinitionId").asString
+        Assert.assertNotNull("reportDefinitionId should be generated", reportDefinitionId)
+        Thread.sleep(100)
+    }
+
+//    fun `test create invalid cron scheduled report definition`() {
+//        var trigger = """
+//            "trigger":{
+//                "triggerType":"CronSchedule"
+//            },
+//        """.trimIndent()
+//        var reportDefinitionRequest = constructReportDefinitionRequest(trigger)
+//        var reportDefinitionResponse = executeRequest(
+//            RestRequest.Method.POST.name,
+//            "$BASE_REPORTS_URI/definition",
+//            reportDefinitionRequest,
+//            400
+//        )
+//        Assert.assertEquals(
+//            "{\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":\"schedule field absent\"}],\"type\":\"illegal_argument_exception\",\"reason\":\"schedule field absent\"},\"status\":400}",
+//            reportDefinitionResponse.toString()
+//        )
+//        Thread.sleep(100)
+//        trigger = """
+//            "trigger":{
+//                "triggerType":"CronSchedule",
+//                "schedule":{
+//                    "cron":{
+//                        "expression":"0 ",
+//                        "timezone":"PST"
+//                    },
+//                },
+//            },
+//        """.trimIndent()
+//        reportDefinitionRequest = constructReportDefinitionRequest(trigger)
+//        reportDefinitionResponse = executeRequest(
+//            RestRequest.Method.POST.name,
+//            "$BASE_REPORTS_URI/definition",
+//            reportDefinitionRequest,
+//            500
+//        )
+//        Assert.assertEquals(
+//            "{\"error\":{\"root_cause\":[{\"type\":\"zone_rules_exception\",\"reason\":\"Unknown time-zone ID: PST\"}],\"type\":\"zone_rules_exception\",\"reason\":\"Unknown time-zone ID: PST\"},\"status\":500}",
+//            reportDefinitionResponse.toString()
+//        )
+//    }
+
+}
+

--- a/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
+++ b/reports-scheduler/src/test/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/rest/ReportDefinitionIT.kt
@@ -17,52 +17,13 @@ package com.amazon.opendistroforelasticsearch.reportsscheduler.rest
 
 import com.amazon.opendistroforelasticsearch.reportsscheduler.PluginRestTestCase
 import com.amazon.opendistroforelasticsearch.reportsscheduler.ReportsSchedulerPlugin.Companion.BASE_REPORTS_URI
+import com.amazon.opendistroforelasticsearch.reportsscheduler.constructReportDefinitionRequest
 import com.amazon.opendistroforelasticsearch.reportsscheduler.validateErrorResponse
 import org.elasticsearch.rest.RestRequest
 import org.elasticsearch.rest.RestStatus
 import org.junit.Assert
 
 class ReportDefinitionIT : PluginRestTestCase() {
-    private fun constructReportDefinitionRequest(
-        trigger: String = """
-            "trigger":{
-                "triggerType":"OnDemand"
-            },
-        """.trimIndent(),
-        name: String = "report_definition"
-    ): String {
-        return """
-            {
-                "reportDefinition":{
-                    "name":"$name",
-                    "isEnabled":true,
-                    "source":{
-                        "description":"description",
-                        "type":"Dashboard",
-                        "origin":"localhost:5601",
-                        "id":"id"
-                    },
-                    "format":{
-                        "duration":"PT1H",
-                        "fileFormat":"Pdf",
-                        "limit":1000,
-                        "header":"optional header",
-                        "footer":"optional footer"
-                    },
-                    $trigger
-                    "delivery":{
-                        "recipients":["nobody@email.com"],
-                        "deliveryFormat":"LinkOnly",
-                        "title":"title",
-                        "textDescription":"textDescription",
-                        "htmlDescription":"optional htmlDescription",
-                        "channelIds":["optional_channelIds"]
-                    }
-                }
-            }
-            """.trimIndent()
-    }
-
     fun `test create, get, update, delete report definition`() {
         val reportDefinitionOnDemandRequest = constructReportDefinitionRequest()
         val reportDefinitionOnDemandResponse = executeRequest(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add integration test cases for report definition rest APIs
- Allow custom error types in validateErrorResponse helper function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
