### PR TITLE
Fixed Edit Report Definition Trigger Type Pre-fill

### DIFF
--- a/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/kibana-reports/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -609,7 +609,8 @@ export function ReportTrigger(props: ReportTriggerProps) {
 
   const defaultEditScheduleFrequency = (trigger_params) => {
     if (trigger_params.schedule_type === SCHEDULE_TYPE_OPTIONS[0].id) {
-      if (trigger_params.schedule.interval.unit === 'DAYS') {
+      if (trigger_params.schedule.interval.unit === 'Days' && 
+          trigger_params.schedule.interval.period === 1) {
         setScheduleRecurringFrequency('daily');
       } else {
         setScheduleRecurringFrequency('byInterval');


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
When going to the `Edit report definition` page for a recurring definition, report definitions that had a `Daily` configuration would always be pre-filled with an interval of `Every 1 minute`. Now, daily definitions correctly fill to `Daily` in `Report trigger`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
