### PR TITLE
Update timeRangeMatcher to avoid create report failure

### DIFF
--- a/kibana-reports/public/components/context_menu/context_menu.js
+++ b/kibana-reports/public/components/context_menu/context_menu.js
@@ -29,12 +29,11 @@ import {
   popoverMenuDiscover,
   getMenuItem,
 } from './context_menu_ui';
+import { timeRangeMatcher } from '../utils/utils';
 
 const replaceQueryURL = () => {
   let url = location.pathname + location.hash;
-  let [, fromDateString, toDateString] = url.match(
-    /time:\(from:(.+),to:(.+?)\)/
-  );
+  let [, fromDateString, toDateString] = url.match(timeRangeMatcher);
   fromDateString = fromDateString.replace(/[']+/g, '');
 
   // convert time range to from date format in case time range is relative

--- a/kibana-reports/public/components/context_menu/context_menu_helpers.js
+++ b/kibana-reports/public/components/context_menu/context_menu_helpers.js
@@ -21,6 +21,7 @@ import {
   reportGenerationFailure,
   permissionsMissingOnGeneration,
 } from './context_menu_ui';
+import { timeRangeMatcher } from '../utils/utils';
 
 const getReportSourceURL = (baseURI) => {
   const url = baseURI.substr(0, baseURI.indexOf('?'));
@@ -34,9 +35,7 @@ export const contextMenuViewReports = () =>
 export const getTimeFieldsFromUrl = () => {
   const url = window.location.href;
 
-  let [, fromDateString, toDateString] = url.match(
-    /time:\(from:(.+),to:(.+?)\)/
-  );
+  let [, fromDateString, toDateString] = url.match(timeRangeMatcher);
   fromDateString = fromDateString.replace(/[']+/g, '');
   // convert time range to from date format in case time range is relative
   const fromDateFormat = dateMath.parse(fromDateString);

--- a/kibana-reports/public/components/main/report_details/report_details.tsx
+++ b/kibana-reports/public/components/main/report_details/report_details.tsx
@@ -38,9 +38,10 @@ import { GenerateReportLoadingModal } from '../loading_modal';
 import { ReportSchemaType } from '../../../../server/model';
 import { converter } from '../../report_definitions/utils';
 import dateMath from '@elastic/datemath';
-import { 
-  permissionsMissingActions, 
-  permissionsMissingToast 
+import {
+  permissionsMissingActions,
+  permissionsMissingToast,
+  timeRangeMatcher,
 } from '../../utils/utils';
 
 export const ReportDetailsComponent = (props) => {
@@ -88,11 +89,11 @@ export function ReportDetails(props) {
       permissionsMissingActions.GENERATING_REPORT
     );
     setToasts(toasts.concat(toast));
-  }
+  };
 
   const handlePermissionsMissingDownloadToast = () => {
     addPermissionsMissingDownloadToastHandler();
-  }
+  };
 
   const addErrorToastHandler = (title = 'Error loading report details.', text = '') => {
     const errorToast = {
@@ -142,7 +143,7 @@ export function ReportDetails(props) {
 
   const parseTimePeriod = (queryUrl: string) => {
     let [timeStringRegEx, fromDateString, toDateString] = queryUrl.match(
-      /time:\(from:(.+),to:(.+?)\)/
+      timeRangeMatcher
     );
 
     fromDateString = fromDateString.replace(/[']+/g, '');
@@ -244,15 +245,13 @@ export function ReportDetails(props) {
       handlePermissionsMissingDownloadToast
     );
     handleLoading(false);
-  }
+  };
 
   const fileFormatDownload = (data) => {
     let formatUpper = data['defaultFileFormat'];
     formatUpper = fileFormatsUpper[formatUpper];
     return (
-      <EuiLink
-        onClick={downloadIconDownload}
-      >
+      <EuiLink onClick={downloadIconDownload}>
         {formatUpper + ' '}
         <EuiIcon type="importAction" />
       </EuiLink>

--- a/kibana-reports/public/components/utils/utils.tsx
+++ b/kibana-reports/public/components/utils/utils.tsx
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import React from "react";
+import React from 'react';
 
 export const permissionsMissingToast = (action: string) => {
   return {
@@ -35,5 +35,7 @@ export const permissionsMissingActions = {
   LOADING_DEFINITIONS_TABLE: 'loading report definitions table.',
   VIEWING_EDIT_PAGE: 'viewing edit page.',
   UPDATING_DEFINITION: 'updating report definition',
-  CREATING_REPORT_DEFINITION: 'creating new report definition.'
-}
+  CREATING_REPORT_DEFINITION: 'creating new report definition.',
+};
+
+export const timeRangeMatcher = /time:\(from:(.+?),to:(.+?)\)/;


### PR DESCRIPTION
*Issue #, if available:*
- Fail to generate report on certain visualization items

*Description of changes:*
- Root cause: the timeRangeMatcher fails on certain input urls. So the `generate report` API call fails to make from client to server
- Solution: update the regex solves the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
