### PR TITLE
Fix the selected fields issue in csv report

### DIFF
--- a/kibana-reports/server/routes/utils/dataReportHelpers.ts
+++ b/kibana-reports/server/routes/utils/dataReportHelpers.ts
@@ -37,14 +37,16 @@ export var metaData = {
 
 // Get the selected columns by the user.
 export const getSelectedFields = async (columns) => {
+  const selectedFields = [];
   for (let column of columns) {
     if (column !== '_source') {
       metaData.fields_exist = true;
-      metaData.selectedFields.push(column);
+      selectedFields.push(column);
     } else {
-      metaData.selectedFields.push('_source');
+      selectedFields.push('_source');
     }
   }
+  metaData.selectedFields = selectedFields;
 };
 
 //Build the ES query from the meta data

--- a/kibana-reports/server/routes/utils/savedSearchReportHelper.ts
+++ b/kibana-reports/server/routes/utils/savedSearchReportHelper.ts
@@ -109,11 +109,13 @@ async function populateMetaData(
       (metaData.timeFieldName = resIndexPattern.timeFieldName),
         (metaData.fields = resIndexPattern.fields); // Get all fields
       // Getting fields of type Date
+      const dateFields = [];
       for (const item of JSON.parse(metaData.fields)) {
         if (item.type === 'date') {
-          metaData.dateFields.push(item.name);
+          dateFields.push(item.name);
         }
       }
+      metaData.dateFields = dateFields;
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

selected fields for saved search not showing as expected on csv reports. issues, all the columns are included instead of the selected fields only.

*Description of changes:*
#### Root cause
There is a global variable `metadata.selectedFields` being used in the csv report logic, which doesn't reset when user switches saved searches.
#### Solution
create scope variable for collecting selected columns and assign to the global variable `metadata`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
