### PR TITLE
Context menu popout & Report definitions Toast fixes

### DIFF
--- a/kibana-reports/public/components/context_menu/context_menu.js
+++ b/kibana-reports/public/components/context_menu/context_menu.js
@@ -121,8 +121,8 @@ const generateInContextReport = (
     }
   )
     .then((response) => {
+      $('#reportGenerationProgressModal').remove();
       if (response.status === 200) {
-        $('#reportGenerationProgressModal').remove();
         addSuccessOrFailureToast('success');
       } else {
         if (response.status === 403) {

--- a/kibana-reports/public/components/main/main.tsx
+++ b/kibana-reports/public/components/main/main.tsx
@@ -191,7 +191,7 @@ export function Main(props) {
       },
     ]);
     refreshReportsTable();
-    refreshReportsDefinitionsTable();
+    // refreshReportsDefinitionsTable();
 
     if (window.location.href.includes('create=success')) {
       handleCreateReportDefinitionSuccessToast();
@@ -199,19 +199,19 @@ export function Main(props) {
       // workaround to wait 1 second and refresh again
       setTimeout(() => {
         refreshReportsTable();
-        refreshReportsDefinitionsTable();
+        // refreshReportsDefinitionsTable();
       }, 1000);
     } else if (window.location.href.includes('edit=success')) {
       handleEditReportDefinitionSuccessToast();
       setTimeout(() => {
         refreshReportsTable();
-        refreshReportsDefinitionsTable();
+        // refreshReportsDefinitionsTable();
       }, 1000);
     } else if (window.location.href.includes('delete=success')) {
-      handleDeleteReportDefinitionSuccessToast();
+      // handleDeleteReportDefinitionSuccessToast();
       setTimeout(() => {
         refreshReportsTable();
-        refreshReportsDefinitionsTable();
+        // refreshReportsDefinitionsTable();
       }, 1000);
     }
     window.location.href = 'opendistro_kibana_reports#/';


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Download in progress modal disappears after any response is received, so it will not remain on-screen after operation is done in error cases
* Commented out report definition toasts since we don't display the report definitions table 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
