### PR TITLE
Fix Context Menu on Index pattern change in Discover

### DIFF
--- a/kibana-reports/public/components/context_menu/context_menu.js
+++ b/kibana-reports/public/components/context_menu/context_menu.js
@@ -228,16 +228,32 @@ $(function () {
   locationHashChanged();
 });
 
+const isDiscoverNavMenu = (navMenu) => {
+  return navMenu[0].children.length === 5 && 
+    ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Discover')
+}
+
+const isDashboardNavMenu = (navMenu) => {
+  return navMenu[0].children.length === 4 && 
+    ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Dashboard')
+}
+
+const isVisualizationNavMenu = (navMenu) => {
+  return navMenu[0].children.length === 3
+    && ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Visualize')
+}
+
 function locationHashChanged() {
   const observer = new MutationObserver(function (mutations) {
     const navMenu = document.querySelectorAll(
       'span.kbnTopNavMenu__wrapper > div.euiFlexGroup'
     );
-    if (navMenu && navMenu.length && navMenu[0].children.length > 1) {
+    if (navMenu && navMenu.length && (
+      isDiscoverNavMenu(navMenu) ||
+      isDashboardNavMenu(navMenu) ||
+      isVisualizationNavMenu(navMenu))
+    ) {
       try {
-        if ($('#downloadReport').length) {
-          return;
-        }
         const menuItem = document.createElement('div');
         menuItem.innerHTML = getMenuItem('Reporting');
         navMenu[0].appendChild(menuItem.children[0]);
@@ -264,9 +280,10 @@ const getUuidFromUrl = () =>
   );
 const isDiscover = () => window.location.href.includes('discover');
 
-window.onhashchange = function () {
+$(window).one('hashchange', function( e ) {    
   locationHashChanged();
-};
+});
+
 /**
  * for navigating to tabs from Kibana sidebar, it uses history.pushState, which doesn't trigger onHashchange.
  * https://stackoverflow.com/questions/4570093/how-to-get-notified-about-changes-of-the-history-via-history-pushstate/4585031
@@ -281,6 +298,6 @@ window.onhashchange = function () {
   };
 })(window.history);
 
-window.onpopstate = history.onpushstate = () => {
+window.onpopstate = () => {
   locationHashChanged();
 };


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Fix in-context menu so it does not disappear when switching index patterns in the `Discover` page
* Instead of checking just that the navMenu length is greater than 1 on Report source pages, checks to make sure the length matches based on the report source type
   * Dashboard nav menu length should be 4
   * Visualization nav menu length should be 3
   * Saved search nav menu length should be 5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
