### PR TITLE
Keep Reporting menu in Nav Menu when switching Index Patterns

### DIFF
--- a/kibana-reports/public/components/context_menu/context_menu.js
+++ b/kibana-reports/public/components/context_menu/context_menu.js
@@ -234,12 +234,34 @@ $(function () {
   locationHashChanged();
 });
 
+const isDiscoverNavMenu = (navMenu) => {
+  return navMenu[0].children.length === 5 && 
+    ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Discover' ||
+    $('[data-test-subj="breadcrumb first last"]').prop('title') === 'Discover')
+}
+
+const isDashboardNavMenu = (navMenu) => {
+  return navMenu[0].children.length === 4 && 
+    ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Dashboard')
+}
+
+const isVisualizationNavMenu = (navMenu) => {
+  return navMenu[0].children.length === 3
+    && ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Visualize')
+}
+
+
+
 function locationHashChanged() {
   const observer = new MutationObserver(function (mutations) {
     const navMenu = document.querySelectorAll(
       'span.kbnTopNavMenu__wrapper > nav.euiHeaderLinks > div.euiHeaderLinks__list'
     );
-    if (navMenu && navMenu.length && navMenu[0].childElementCount > 1) {
+    if (navMenu && navMenu.length && (
+      isDiscoverNavMenu(navMenu) ||
+      isDashboardNavMenu(navMenu) ||
+      isVisualizationNavMenu(navMenu))
+    ) {
       try {
         if ($('#downloadReport').length) {
           return;
@@ -263,9 +285,9 @@ function locationHashChanged() {
   });
 }
 
-window.onhashchange = function () {
+$(window).one('hashchange', function( e ) {    
   locationHashChanged();
-};
+});
 /**
  * for navigating to tabs from Kibana sidebar, it uses history.pushState, which doesn't trigger onHashchange.
  * https://stackoverflow.com/questions/4570093/how-to-get-notified-about-changes-of-the-history-via-history-pushstate/4585031

--- a/kibana-reports/public/components/context_menu/context_menu.js
+++ b/kibana-reports/public/components/context_menu/context_menu.js
@@ -241,7 +241,7 @@ const isDiscoverNavMenu = (navMenu) => {
 }
 
 const isDashboardNavMenu = (navMenu) => {
-  return navMenu[0].children.length === 4 && 
+  return (navMenu[0].children.length === 4 || navMenu[0].children.length === 6) && 
     ($('[data-test-subj="breadcrumb first"]').prop('title') === 'Dashboard')
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Fix in-context menu so it does not disappear when switching index patterns in the `Discover` page
* Instead of checking just that the navMenu length is greater than 1 on Report source pages, checks to make sure the length matches based on the report source type
   * Dashboard nav menu length should be 4
   * Visualization nav menu length should be 3
   * Saved search nav menu length should be 5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
