### PR TITLE
Change release workflows to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -1,9 +1,12 @@
 name: Release Kibana Reports Artifacts
 
 on:
+  # push:
+  #   tags:
+  #     - "v*"
   push:
-    tags:
-      - "v*"
+    branches:
+      - "release-workflow-patch"
 
 env:
   PLUGIN_NAME: opendistroReportsKibana
@@ -17,8 +20,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Checkout Plugin
@@ -62,7 +65,7 @@ jobs:
           max_attempts: 3
           command: cd kibana/plugins/${{ env.PLUGIN_NAME }}; yarn test
 
-      - name: Build Artifact
+      - name: Build Artifact and upload to S3
         run: |
           cd kibana/plugins/${{ env.PLUGIN_NAME }}
           yarn build
@@ -72,6 +75,7 @@ jobs:
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
           mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/reports/"
 
           cd linux-x64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
@@ -79,7 +83,11 @@ jobs:
           rm chromium-linux-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
-          aws s3 cp $linux_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/linux/x64/
+
+          #Inject build number before the suffix and upload to S3
+          linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          echo "Copying $linux_artifact to ${s3_prefix}${linux_artifact_outfile}"
+          aws s3 cp --quiet $linux_artifact ${s3_prefix}${linux_artifact_outfile}
           cd ..
 
           cd linux-arm64
@@ -88,7 +96,11 @@ jobs:
           rm chromium-linux-arm64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
-          aws s3 cp $arm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/linux/arm64/
+
+          #Inject build number before the suffix and upload to S3
+          arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          echo "Copying $arm_artifact to ${s3_prefix}${arm_artifact_outfile}"
+          aws s3 cp --quiet $arm_artifact ${s3_prefix}${arm_artifact_outfile}
           cd ..
 
           cd windows-x64
@@ -97,7 +109,8 @@ jobs:
           rm chromium-windows-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
-          aws s3 cp $windows_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/windows/x64/
-          cd ..
 
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"
+          #Inject build number before the suffix and upload to S3
+          windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          echo "Copying $windows_artifact to ${s3_prefix}${windows_artifact_outfile}"
+          aws s3 cp --quiet $windows_artifact ${s3_prefix}${windows_artifact_outfile}

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - "release-workflow-patch"
 
 env:
   PLUGIN_NAME: opendistroReportsKibana
@@ -81,7 +83,7 @@ jobs:
           rm chromium-linux-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip`
-          
+
           #Inject build number before the suffix and upload to S3
           linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $linux_artifact to ${s3_prefix}${linux_artifact_outfile}"

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -1,12 +1,9 @@
 name: Release Kibana Reports Artifacts
 
 on:
-  # push:
-  #   tags:
-  #     - "v*"
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - "v*"
 
 env:
   PLUGIN_NAME: opendistroReportsKibana
@@ -75,6 +72,7 @@ jobs:
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
           cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
           mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
+
           s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/kibana-plugins/reports/"
 
           cd linux-x64

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -80,12 +80,12 @@ jobs:
           unzip chromium-linux-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip`
+          linux_x64_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip`
 
           #Inject build number before the suffix and upload to S3
-          linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
-          echo "Copying $linux_artifact to ${s3_prefix}${linux_artifact_outfile}"
-          aws s3 cp --quiet $linux_artifact ${s3_prefix}${linux_artifact_outfile}
+          linux_x64_artifact_outfile=`basename ${linux_x64_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          echo "Copying $linux_x64_artifact to ${s3_prefix}${linux_x64_artifact_outfile}"
+          aws s3 cp --quiet $linux_x64_artifact ${s3_prefix}${linux_x64_artifact_outfile}
           cd ..
 
           cd linux-arm64
@@ -93,12 +93,12 @@ jobs:
           unzip chromium-linux-arm64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-arm64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip`
+          linux_arm64_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip`
 
           #Inject build number before the suffix and upload to S3
-          arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
-          echo "Copying $arm_artifact to ${s3_prefix}${arm_artifact_outfile}"
-          aws s3 cp --quiet $arm_artifact ${s3_prefix}${arm_artifact_outfile}
+          linux_arm64_artifact_outfile=`basename ${linux_arm64_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          echo "Copying $linux_arm64_artifact to ${s3_prefix}${linux_arm64_artifact_outfile}"
+          aws s3 cp --quiet $linux_arm64_artifact ${s3_prefix}${linux_arm64_artifact_outfile}
           cd ..
 
           cd windows-x64
@@ -106,9 +106,9 @@ jobs:
           unzip chromium-windows-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-windows-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip`
+          windows_x64_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip`
 
           #Inject build number before the suffix and upload to S3
-          windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
-          echo "Copying $windows_artifact to ${s3_prefix}${windows_artifact_outfile}"
-          aws s3 cp --quiet $windows_artifact ${s3_prefix}${windows_artifact_outfile}
+          windows_x64_artifact_outfile=`basename ${windows_x64_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          echo "Copying $windows_x64_artifact to ${s3_prefix}${windows_x64_artifact_outfile}"
+          aws s3 cp --quiet $windows_x64_artifact ${s3_prefix}${windows_x64_artifact_outfile}

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -83,7 +83,7 @@ jobs:
           linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          linux_artifact_outfile=`basename ${linux_artifact%.zip}-linux-x64-build-${GITHUB_RUN_NUMBER}.zip`
+          linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $linux_artifact to ${s3_prefix}${linux_artifact_outfile}"
           aws s3 cp --quiet $linux_artifact ${s3_prefix}${linux_artifact_outfile}
           cd ..
@@ -96,7 +96,7 @@ jobs:
           arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          arm_artifact_outfile=`basename ${arm_artifact%.zip}-linux-arm64-build-${GITHUB_RUN_NUMBER}.zip`
+          arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $arm_artifact to ${s3_prefix}${arm_artifact_outfile}"
           aws s3 cp --quiet $arm_artifact ${s3_prefix}${arm_artifact_outfile}
           cd ..
@@ -109,6 +109,6 @@ jobs:
           windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          windows_artifact_outfile=`basename ${windows_artifact%.zip}-windows-x64-build-${GITHUB_RUN_NUMBER}.zip`
+          windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $windows_artifact to ${s3_prefix}${windows_artifact_outfile}"
           aws s3 cp --quiet $windows_artifact ${s3_prefix}${windows_artifact_outfile}

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -109,7 +109,6 @@ jobs:
           rm chromium-windows-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
           windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip`
-          cd ..
 
           #Inject build number before the suffix and upload to S3
           windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -82,7 +82,7 @@ jobs:
           unzip chromium-linux-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
+          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip`
 
           #Inject build number before the suffix and upload to S3
           linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
@@ -95,7 +95,7 @@ jobs:
           unzip chromium-linux-arm64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-arm64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
+          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip`
 
           #Inject build number before the suffix and upload to S3
           arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
@@ -108,7 +108,7 @@ jobs:
           unzip chromium-windows-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-windows-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
+          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip`
 
           #Inject build number before the suffix and upload to S3
           windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "release-workflow-patch"
 
 env:
   PLUGIN_NAME: opendistroReportsKibana

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -82,10 +82,10 @@ jobs:
           unzip chromium-linux-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip`
+          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}-linux-x64.zip`
           echo "Copying $linux_artifact to ${s3_prefix}${linux_artifact_outfile}"
           aws s3 cp --quiet $linux_artifact ${s3_prefix}${linux_artifact_outfile}
           cd ..
@@ -95,10 +95,10 @@ jobs:
           unzip chromium-linux-arm64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-arm64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip`
+          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}-linux-arm64.zip`
           echo "Copying $arm_artifact to ${s3_prefix}${arm_artifact_outfile}"
           aws s3 cp --quiet $arm_artifact ${s3_prefix}${arm_artifact_outfile}
           cd ..
@@ -108,9 +108,9 @@ jobs:
           unzip chromium-windows-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-windows-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip`
+          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}-windows-x64.zip`
           echo "Copying $windows_artifact to ${s3_prefix}${windows_artifact_outfile}"
           aws s3 cp --quiet $windows_artifact ${s3_prefix}${windows_artifact_outfile}

--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -85,7 +85,7 @@ jobs:
           linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          linux_artifact_outfile=`basename ${linux_artifact%.zip}-build-${GITHUB_RUN_NUMBER}-linux-x64.zip`
+          linux_artifact_outfile=`basename ${linux_artifact%.zip}-linux-x64-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $linux_artifact to ${s3_prefix}${linux_artifact_outfile}"
           aws s3 cp --quiet $linux_artifact ${s3_prefix}${linux_artifact_outfile}
           cd ..
@@ -98,7 +98,7 @@ jobs:
           arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          arm_artifact_outfile=`basename ${arm_artifact%.zip}-build-${GITHUB_RUN_NUMBER}-linux-arm64.zip`
+          arm_artifact_outfile=`basename ${arm_artifact%.zip}-linux-arm64-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $arm_artifact to ${s3_prefix}${arm_artifact_outfile}"
           aws s3 cp --quiet $arm_artifact ${s3_prefix}${arm_artifact_outfile}
           cd ..
@@ -111,6 +111,6 @@ jobs:
           windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
 
           #Inject build number before the suffix and upload to S3
-          windows_artifact_outfile=`basename ${windows_artifact%.zip}-build-${GITHUB_RUN_NUMBER}-windows-x64.zip`
+          windows_artifact_outfile=`basename ${windows_artifact%.zip}-windows-x64-build-${GITHUB_RUN_NUMBER}.zip`
           echo "Copying $windows_artifact to ${s3_prefix}${windows_artifact_outfile}"
           aws s3 cp --quiet $windows_artifact ${s3_prefix}${windows_artifact_outfile}

--- a/.github/workflows/reports-scheduler-release-workflow.yml
+++ b/.github/workflows/reports-scheduler-release-workflow.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload plugin artifacts to S3
         shell: bash
         run: |
-          ls -ltr
+          cd reports-scheduler
           zip=`ls build/distributions/*.zip`
           rpm=`ls build/distributions/*.rpm`
           deb=`ls build/distributions/*.deb`

--- a/.github/workflows/reports-scheduler-release-workflow.yml
+++ b/.github/workflows/reports-scheduler-release-workflow.yml
@@ -1,9 +1,12 @@
 name: Release Reports Scheduler Artifacts
 # This workflow is triggered on creating tags to master or an opendistro release branch
 on:
+  # push:
+  #   tags:
+  #     - "v*"
   push:
-    tags:
-      - "v*"
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   build:
@@ -13,8 +16,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Checkout Plugin
@@ -29,11 +32,26 @@ jobs:
         run: |
           cd reports-scheduler
           ./gradlew build buildDeb buildRpm --no-daemon --refresh-dependencies -Dbuild.snapshot=false
-          artifact=`ls ./build/distributions/*.zip`
-          rpm_artifact=`ls ./build/distributions/*.rpm`
-          deb_artifact=`ls ./build/distributions/*.deb`
 
-          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-reports-scheduler/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-reports-scheduler/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-reports-scheduler/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"
+      - name: Upload plugin artifacts to S3
+        shell: bash
+        run: |
+          zip=`ls build/distributions/*.zip`
+          rpm=`ls build/distributions/*.rpm`
+          deb=`ls build/distributions/*.deb`
+
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-plugins/reports-scheduler/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+          
+          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}

--- a/.github/workflows/reports-scheduler-release-workflow.yml
+++ b/.github/workflows/reports-scheduler-release-workflow.yml
@@ -36,9 +36,10 @@ jobs:
       - name: Upload plugin artifacts to S3
         shell: bash
         run: |
-          zip=`ls ./build/distributions/*.zip`
-          rpm=`ls ./build/distributions/*.rpm`
-          deb=`ls ./build/distributions/*.deb`
+          ls -ltr
+          zip=`ls build/distributions/*.zip`
+          rpm=`ls build/distributions/*.rpm`
+          deb=`ls build/distributions/*.deb`
 
           # Inject the build number before the suffix
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`

--- a/.github/workflows/reports-scheduler-release-workflow.yml
+++ b/.github/workflows/reports-scheduler-release-workflow.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Upload plugin artifacts to S3
         shell: bash
         run: |
-          zip=`ls build/distributions/*.zip`
-          rpm=`ls build/distributions/*.rpm`
-          deb=`ls build/distributions/*.deb`
+          zip=`ls ./build/distributions/*.zip`
+          rpm=`ls ./build/distributions/*.rpm`
+          deb=`ls ./build/distributions/*.deb`
 
           # Inject the build number before the suffix
           zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
@@ -49,9 +49,9 @@ jobs:
 
           echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
           aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
-
+          
           echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
           aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
-          
+
           echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
           aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}

--- a/.github/workflows/reports-scheduler-release-workflow.yml
+++ b/.github/workflows/reports-scheduler-release-workflow.yml
@@ -1,12 +1,9 @@
 name: Release Reports Scheduler Artifacts
 # This workflow is triggered on creating tags to master or an opendistro release branch
 on:
-  # push:
-  #   tags:
-  #     - "v*"
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - "v*"
 
 jobs:
   build:
@@ -33,7 +30,7 @@ jobs:
           cd reports-scheduler
           ./gradlew build buildDeb buildRpm --no-daemon --refresh-dependencies -Dbuild.snapshot=false
 
-      - name: Upload plugin artifacts to S3
+      - name: Upload to S3
         shell: bash
         run: |
           cd reports-scheduler

--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -15,7 +15,7 @@
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",
     "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "cypress:run": "../../node_modules/.bin/cypress run",
+    "cypress:run": "../node_modules/.bin/cypress run",
     "cypress:open": "../../node_modules/.bin/cypress open",
     "plugin_helpers": "node ../../scripts/plugin_helpers"
   },

--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -15,7 +15,7 @@
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",
     "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "cypress:run": "../node_modules/.bin/cypress run",
+    "cypress:run": "cypress run",
     "cypress:open": "../../node_modules/.bin/cypress open",
     "plugin_helpers": "node ../../scripts/plugin_helpers"
   },

--- a/kibana-reports/package.json
+++ b/kibana-reports/package.json
@@ -15,7 +15,7 @@
     "start": "yarn plugin_helpers start",
     "build": "yarn plugin_helpers build",
     "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "cypress:run": "cypress run",
+    "cypress:run": "../../node_modules/.bin/cypress run",
     "cypress:open": "../../node_modules/.bin/cypress open",
     "plugin_helpers": "node ../../scripts/plugin_helpers"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations. This PR changes the CD workflow to add a build number and write the zip artifact to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Results: 
https://github.com/gaiksaya/kibana-reports/runs/1746023375?check_suite_focus=true

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
