### PR TITLE
Rename kibana reports release artifacts in github workflow

### DIFF
--- a/.github/workflows/kibana-reports-release-workflow.yml
+++ b/.github/workflows/kibana-reports-release-workflow.yml
@@ -69,16 +69,16 @@ jobs:
 
           cd build
           mkdir -p ./{linux-x64,linux-arm64,windows-x64}/kibana/${{ env.PLUGIN_NAME }}
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
-          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
-          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip
+          cp ./${{ env.PLUGIN_NAME }}-*.zip ./linux-arm64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip
+          mv ./${{ env.PLUGIN_NAME }}-*.zip ./windows-x64/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip
 
           cd linux-x64
           wget https://github.com/opendistro-for-elasticsearch/kibana-reports/releases/download/chromium-1.12.0.0/chromium-linux-x64.zip
           unzip chromium-linux-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
+          linux_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-x64.zip`
           aws s3 cp $linux_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/linux/x64/
           cd ..
 
@@ -87,7 +87,7 @@ jobs:
           unzip chromium-linux-arm64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-linux-arm64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
+          arm_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-linux-arm64.zip`
           aws s3 cp $arm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/linux/arm64/
           cd ..
 
@@ -96,7 +96,7 @@ jobs:
           unzip chromium-windows-x64.zip -d ./kibana/${{ env.PLUGIN_NAME }}
           rm chromium-windows-x64.zip
           zip -ur ./${{ env.PLUGIN_NAME }}-*.zip ./kibana
-          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip`
+          windows_artifact=`ls ./${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}-windows-x64.zip`
           aws s3 cp $windows_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-reports/windows/x64/
           cd ..
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This PR partially reverts #233. Kibana reports artifacts will now have the following names when uploading to S3. The S3 bucket path will be updated by #301 
```
opendistroReportsKibana-1.12.0.0-linux-x64.zip
opendistroReportsKibana-1.12.0.0-linux-arm64.zip
opendistroReportsKibana-1.12.0.0-windows-x64.zip
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
