### PR TITLE
Add reporting backend to Codecov

### DIFF
--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -50,7 +50,7 @@ jobs:
           max_attempts: 3
           command: cd kibana/plugins/${{ env.PLUGIN_NAME }}; yarn test --coverage
 
-      - name: Uploads coverage
+      - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
           flags: Kibana plugin

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
-          flags: Kibana plugin
+          flags: Kibana-reports
           directory: kibana/plugins/
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
         with:
+          flags: frontend
+          directory: kibana/plugins/
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build Artifact

--- a/.github/workflows/kibana-reports-test-and-build-workflow.yml
+++ b/.github/workflows/kibana-reports-test-and-build-workflow.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
         with:
-          flags: frontend
+          flags: Kibana plugin
           directory: kibana/plugins/
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
         with:
-          flags: backend
+          flags: ES plugin
           directory: reports-scheduler/
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
-          flags: ES plugin
+          flags: reports-scheduler
           directory: reports-scheduler/
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -19,6 +19,13 @@ jobs:
           cd reports-scheduler
           ./gradlew build
 
+      - name: Uploads coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: backend
+          directory: reports-scheduler/
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Create Artifact Path
         run: |
           mkdir -p reports-scheduler-builds

--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -19,7 +19,7 @@ jobs:
           cd reports-scheduler
           ./gradlew build
 
-      - name: Uploads coverage
+      - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
           flags: ES plugin


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update github actiuon script, use `flag` and `directory` parameter to enable uploading test coverage for multiple projects in one repo. In our case, kibana-reports plugin and reports-scheduler plugin. 

Ref: https://docs.codecov.io/docs/flags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
