### PR TITLE
Rename deb and rpm packages for reports scheduler

### DIFF
--- a/reports-scheduler/build-tools/pkgbuild.gradle
+++ b/reports-scheduler/build-tools/pkgbuild.gradle
@@ -50,13 +50,29 @@ afterEvaluate {
 
     buildRpm {
         arch = 'NOARCH'
-        archiveName "${packageName}-${version}.rpm"
+        archiveName "${packageName}-${version}-1.noarch.rpm"
         dependsOn 'assemble'
+        finalizedBy 'renameRpm'
+        task renameRpm(type: Copy) {
+            from("$buildDir/distributions")
+            into("$buildDir/distributions")
+            include archiveName
+            rename archiveName, "${packageName}-${version}.rpm"
+            doLast { delete file("$buildDir/distributions/$archiveName") }
+        }
     }
 
     buildDeb {
         arch = 'amd64'
-        archiveName "${packageName}-${version}.deb"
+        archiveName "${packageName}_${version}-1_amd64.deb"
         dependsOn 'assemble'
+        finalizedBy 'renameDeb'
+        task renameDeb(type: Copy) {
+            from("$buildDir/distributions")
+            into("$buildDir/distributions")
+            include archiveName
+            rename archiveName, "${packageName}-${version}.deb"
+            doLast { delete file("$buildDir/distributions/$archiveName") }
+        }
     }
 }

--- a/reports-scheduler/build-tools/pkgbuild.gradle
+++ b/reports-scheduler/build-tools/pkgbuild.gradle
@@ -50,7 +50,6 @@ afterEvaluate {
 
     buildRpm {
         arch = 'NOARCH'
-        archiveName "${packageName}-${version}-1.noarch.rpm"
         dependsOn 'assemble'
         finalizedBy 'renameRpm'
         task renameRpm(type: Copy) {
@@ -63,8 +62,7 @@ afterEvaluate {
     }
 
     buildDeb {
-        arch = 'amd64'
-        archiveName "${packageName}_${version}-1_amd64.deb"
+        arch = 'all'
         dependsOn 'assemble'
         finalizedBy 'renameDeb'
         task renameDeb(type: Copy) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
rename reports scheduler to `opendistro-reports-scheduler-1.12.0.0.rpm` and `opendistro-reports-scheduler-1.12.0.0.deb`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
