### PR TITLE
Support customized server config

### DIFF
--- a/kibana-reports/server/index.ts
+++ b/kibana-reports/server/index.ts
@@ -13,8 +13,34 @@
  * permissions and limitations under the License.
  */
 
-import { PluginInitializerContext } from '../../../src/core/server';
 import { OpendistroKibanaReportsPlugin } from './plugin';
+import { schema, TypeOf } from '@kbn/config-schema';
+import {
+  PluginInitializerContext,
+  PluginConfigDescriptor,
+  HttpServerInfo,
+} from '../../../src/core/server';
+
+export const configSchema = schema.object({
+  access: schema.object({
+    port: schema.number({ defaultValue: 5601 }),
+    basePath: schema.string({ defaultValue: '' }),
+  }),
+});
+
+export type KibanaReportsPluginConfigType = TypeOf<typeof configSchema>;
+
+export const config: PluginConfigDescriptor<KibanaReportsPluginConfigType> = {
+  exposeToBrowser: {
+    access: true,
+  },
+  schema: configSchema,
+};
+
+export type AccessInfoType = {
+  basePath: string;
+  serverInfo: HttpServerInfo;
+};
 
 //  This exports static code and TypeScript types,
 //  as well as, Kibana Platform `plugin()` initializer.

--- a/kibana-reports/server/index.ts
+++ b/kibana-reports/server/index.ts
@@ -14,28 +14,10 @@
  */
 
 import { OpendistroKibanaReportsPlugin } from './plugin';
-import { schema, TypeOf } from '@kbn/config-schema';
 import {
   PluginInitializerContext,
-  PluginConfigDescriptor,
   HttpServerInfo,
 } from '../../../src/core/server';
-
-export const configSchema = schema.object({
-  access: schema.object({
-    port: schema.number({ defaultValue: 5601 }),
-    basePath: schema.string({ defaultValue: '' }),
-  }),
-});
-
-export type KibanaReportsPluginConfigType = TypeOf<typeof configSchema>;
-
-export const config: PluginConfigDescriptor<KibanaReportsPluginConfigType> = {
-  exposeToBrowser: {
-    access: true,
-  },
-  schema: configSchema,
-};
 
 export type AccessInfoType = {
   basePath: string;

--- a/kibana-reports/server/plugin.ts
+++ b/kibana-reports/server/plugin.ts
@@ -33,7 +33,6 @@ import registerRoutes from './routes';
 import { pollAndExecuteJob } from './executor/executor';
 import { POLL_INTERVAL } from './utils/constants';
 import { AccessInfoType, KibanaReportsPluginConfigType } from 'server';
-import { first } from 'rxjs/operators';
 
 export interface ReportsPluginRequestContext {
   logger: Logger;
@@ -55,7 +54,7 @@ export class OpendistroKibanaReportsPlugin
   private readonly logger: Logger;
   private readonly semaphore: SemaphoreInterface;
 
-  constructor(private readonly initializerContext: PluginInitializerContext) {
+  constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
 
     const timeoutError = new Error('Server busy');
@@ -63,11 +62,9 @@ export class OpendistroKibanaReportsPlugin
     this.semaphore = withTimeout(new Semaphore(1), 180000, timeoutError);
   }
 
-  public async setup(core: CoreSetup) {
+  public setup(core: CoreSetup) {
     this.logger.debug('opendistro_kibana_reports: Setup');
 
-    // const config$ = this.initializerContext.config.create<KibanaReportsPluginConfigType>();
-    // const config: KibanaReportsPluginConfigType = await config$.pipe(first()).toPromise();
     const config = core.http.getServerInfo();
     const serverBasePath = core.http.basePath.serverBasePath;
     const accessInfo: AccessInfoType = {

--- a/kibana-reports/server/plugin.ts
+++ b/kibana-reports/server/plugin.ts
@@ -32,7 +32,7 @@ import {
 import registerRoutes from './routes';
 import { pollAndExecuteJob } from './executor/executor';
 import { POLL_INTERVAL } from './utils/constants';
-import { AccessInfoType, KibanaReportsPluginConfigType } from 'server';
+import { AccessInfoType } from 'server';
 
 export interface ReportsPluginRequestContext {
   logger: Logger;

--- a/kibana-reports/server/plugin.ts
+++ b/kibana-reports/server/plugin.ts
@@ -32,6 +32,8 @@ import {
 import registerRoutes from './routes';
 import { pollAndExecuteJob } from './executor/executor';
 import { POLL_INTERVAL } from './utils/constants';
+import { AccessInfoType, KibanaReportsPluginConfigType } from 'server';
+import { first } from 'rxjs/operators';
 
 export interface ReportsPluginRequestContext {
   logger: Logger;
@@ -53,7 +55,7 @@ export class OpendistroKibanaReportsPlugin
   private readonly logger: Logger;
   private readonly semaphore: SemaphoreInterface;
 
-  constructor(initializerContext: PluginInitializerContext) {
+  constructor(private readonly initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
 
     const timeoutError = new Error('Server busy');
@@ -61,8 +63,18 @@ export class OpendistroKibanaReportsPlugin
     this.semaphore = withTimeout(new Semaphore(1), 180000, timeoutError);
   }
 
-  public setup(core: CoreSetup) {
+  public async setup(core: CoreSetup) {
     this.logger.debug('opendistro_kibana_reports: Setup');
+
+    // const config$ = this.initializerContext.config.create<KibanaReportsPluginConfigType>();
+    // const config: KibanaReportsPluginConfigType = await config$.pipe(first()).toPromise();
+    const config = core.http.getServerInfo();
+    const serverBasePath = core.http.basePath.serverBasePath;
+    const accessInfo: AccessInfoType = {
+      basePath: serverBasePath,
+      serverInfo: config,
+    };
+
     const router = core.http.createRouter();
     // Deprecated API. Switch to the new elasticsearch client as soon as https://github.com/elastic/kibana/issues/35508 done.
     const esReportsClient: ILegacyClusterClient = core.elasticsearch.legacy.createClient(
@@ -78,9 +90,8 @@ export class OpendistroKibanaReportsPlugin
         plugins: [notificationPlugin],
       }
     );
-
     // Register server side APIs
-    registerRoutes(router);
+    registerRoutes(router, accessInfo);
 
     // put logger into route handler context, so that we don't need to pass through parameters
     core.http.registerRouteHandlerContext(
@@ -101,7 +112,6 @@ export class OpendistroKibanaReportsPlugin
 
   public start(core: CoreStart) {
     this.logger.debug('opendistro_kibana_reports: Started');
-
     const esReportsClient: ILegacyClusterClient = core.elasticsearch.legacy.createClient(
       'es_reports',
       {

--- a/kibana-reports/server/routes/index.ts
+++ b/kibana-reports/server/routes/index.ts
@@ -17,8 +17,8 @@ import registerReportRoute from './report';
 import registerReportDefinitionRoute from './reportDefinition';
 import registerReportSourceRoute from './reportSource';
 import registerMetricRoute from './metric';
-import { HttpServerInfo, IRouter } from '../../../../src/core/server';
-import { AccessInfoType, KibanaReportsPluginConfigType } from 'server';
+import { IRouter } from '../../../../src/core/server';
+import { AccessInfoType } from 'server';
 
 export default function (router: IRouter, accessInfo: AccessInfoType) {
   registerReportRoute(router, accessInfo);

--- a/kibana-reports/server/routes/index.ts
+++ b/kibana-reports/server/routes/index.ts
@@ -17,11 +17,12 @@ import registerReportRoute from './report';
 import registerReportDefinitionRoute from './reportDefinition';
 import registerReportSourceRoute from './reportSource';
 import registerMetricRoute from './metric';
-import { IRouter } from '../../../../src/core/server';
+import { HttpServerInfo, IRouter } from '../../../../src/core/server';
+import { AccessInfoType, KibanaReportsPluginConfigType } from 'server';
 
-export default function (router: IRouter) {
-  registerReportRoute(router);
-  registerReportDefinitionRoute(router);
+export default function (router: IRouter, accessInfo: AccessInfoType) {
+  registerReportRoute(router, accessInfo);
+  registerReportDefinitionRoute(router, accessInfo);
   registerReportSourceRoute(router);
   registerMetricRoute(router);
 }

--- a/kibana-reports/server/routes/reportDefinition.ts
+++ b/kibana-reports/server/routes/reportDefinition.ts
@@ -31,8 +31,10 @@ import { updateReportDefinition } from './lib/updateReportDefinition';
 import { DEFAULT_MAX_SIZE } from './utils/constants';
 import { addToMetric } from './utils/metricHelper';
 import { validateReportDefinition } from '../../server/utils/validationHelper';
+import { AccessInfoType } from 'server';
 
-export default function (router: IRouter) {
+export default function (router: IRouter, accessInfo: AccessInfoType) {
+  const { basePath, serverInfo } = accessInfo;
   // Create report Definition
   router.post(
     {
@@ -56,7 +58,8 @@ export default function (router: IRouter) {
           request.headers.origin;
         reportDefinition = await validateReportDefinition(
           context.core.elasticsearch.legacy.client,
-          reportDefinition
+          reportDefinition,
+          basePath
         );
       } catch (error) {
         logger.error(
@@ -114,7 +117,8 @@ export default function (router: IRouter) {
           request.headers.origin;
         reportDefinition = await validateReportDefinition(
           context.core.elasticsearch.legacy.client,
-          reportDefinition
+          reportDefinition,
+          basePath
         );
       } catch (error) {
         logger.error(
@@ -182,7 +186,8 @@ export default function (router: IRouter) {
         );
 
         const reportDefinitionsList = backendToUiReportDefinitionsList(
-          esResp.reportDefinitionDetailsList
+          esResp.reportDefinitionDetailsList,
+          basePath
         );
 
         return response.ok({
@@ -231,7 +236,8 @@ export default function (router: IRouter) {
         );
 
         const reportDefinition = backendToUiReportDefinition(
-          esResp.reportDefinitionDetails
+          esResp.reportDefinitionDetails,
+          basePath
         );
 
         return response.ok({

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -73,7 +73,7 @@ export enum SELECTOR {
 // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-from-size.html
 export const DEFAULT_MAX_SIZE = 10000;
 
-export const LOCAL_HOST = 'http://localhost:5601';
+export const LOCAL_HOST = 'localhost';
 
 export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -73,8 +73,6 @@ export enum SELECTOR {
 // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-from-size.html
 export const DEFAULT_MAX_SIZE = 10000;
 
-export const LOCAL_HOST = 'localhost';
-
 export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 
 export const SECURITY_AUTH_COOKIE_NAME = 'security_authentication';

--- a/kibana-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
+++ b/kibana-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+import { KibanaReportsPluginConfigType } from 'server';
 import {
   BackendReportInstanceType,
   BACKEND_DELIVERY_FORMAT,
@@ -73,6 +74,13 @@ const input: BackendReportInstanceType = {
   status: BACKEND_REPORT_STATE.success,
 };
 
+const testConfig: KibanaReportsPluginConfigType = {
+  access: {
+    port: 5601,
+    basePath: '',
+  },
+};
+
 const output = {
   query_url:
     "/app/dashboards#/view/722b74f0-b882-11e8-a6d9-e546fe2bba5f?_g=(time:(from:'2020-11-11T00:32:00.000Z',to:'2020-11-11T01:02:00.000Z'))",
@@ -125,7 +133,7 @@ const output = {
 
 describe('test backend to ui model conversion', () => {
   test('convert backend to ui report', async () => {
-    const res = backendToUiReport(input);
+    const res = backendToUiReport(input, testConfig.access.basePath);
     expect(res).toEqual(output);
   }, 20000);
 });

--- a/kibana-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
+++ b/kibana-reports/server/routes/utils/converters/__tests__/backendToUi.test.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import { KibanaReportsPluginConfigType } from 'server';
+import { AccessInfoType } from 'server';
 import {
   BackendReportInstanceType,
   BACKEND_DELIVERY_FORMAT,
@@ -74,10 +74,13 @@ const input: BackendReportInstanceType = {
   status: BACKEND_REPORT_STATE.success,
 };
 
-const testConfig: KibanaReportsPluginConfigType = {
-  access: {
+const testAccessInfo: AccessInfoType = {
+  basePath: '',
+  serverInfo: {
+    name: '',
+    hostname: 'localhost',
     port: 5601,
-    basePath: '',
+    protocol: 'http',
   },
 };
 
@@ -133,7 +136,7 @@ const output = {
 
 describe('test backend to ui model conversion', () => {
   test('convert backend to ui report', async () => {
-    const res = backendToUiReport(input, testConfig.access.basePath);
+    const res = backendToUiReport(input, testAccessInfo.basePath);
     expect(res).toEqual(output);
   }, 20000);
 });

--- a/kibana-reports/server/routes/utils/helpers.ts
+++ b/kibana-reports/server/routes/utils/helpers.ts
@@ -19,7 +19,6 @@ import {
   ILegacyClusterClient,
   ILegacyScopedClusterClient,
 } from '../../../../../src/core/server';
-import { ReportSchemaType } from 'server/model';
 
 /**
  * ES error response body:
@@ -94,22 +93,4 @@ export const checkErrorType = (error: any) => {
   } else {
     return 'system_error';
   }
-};
-
-export const validate = (schema: any, content: any, basePath: string) => {
-  // report
-  if (content.query_url) {
-    content.query_url = content.query_url.replace(basePath, '');
-    content.report_definition.report_params.core_params.base_url = content.report_definition.report_params.core_params.base_url.replace(
-      basePath,
-      ''
-    );
-  } else {
-    // report definition
-    content.report_params.core_params.base_url = content.report_params.core_params.base_url.replace(
-      basePath,
-      ''
-    );
-  }
-  return schema.validate(content);
 };

--- a/kibana-reports/server/routes/utils/helpers.ts
+++ b/kibana-reports/server/routes/utils/helpers.ts
@@ -19,6 +19,7 @@ import {
   ILegacyClusterClient,
   ILegacyScopedClusterClient,
 } from '../../../../../src/core/server';
+import { ReportSchemaType } from 'server/model';
 
 /**
  * ES error response body:
@@ -93,4 +94,22 @@ export const checkErrorType = (error: any) => {
   } else {
     return 'system_error';
   }
+};
+
+export const validate = (schema: any, content: any, basePath: string) => {
+  // report
+  if (content.query_url) {
+    content.query_url = content.query_url.replace(basePath, '');
+    content.report_definition.report_params.core_params.base_url = content.report_definition.report_params.core_params.base_url.replace(
+      basePath,
+      ''
+    );
+  } else {
+    // report definition
+    content.report_params.core_params.base_url = content.report_params.core_params.base_url.replace(
+      basePath,
+      ''
+    );
+  }
+  return schema.validate(content);
 };

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -66,8 +66,15 @@ export const createVisualReport = async (
      * TODO: temp fix to disable sandbox when launching chromium on Linux instance
      * https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
      */
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu', '--no-zygote', '--single-process'],
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-gpu',
+      '--no-zygote',
+      '--single-process',
+    ],
     executablePath: CHROMIUM_PATH,
+    ignoreHTTPSErrors: true,
     env: {
       TZ: timezone || 'UTC',
     },

--- a/kibana-reports/server/utils/validationHelper.ts
+++ b/kibana-reports/server/utils/validationHelper.ts
@@ -45,8 +45,14 @@ export const regexRelativeUrl = /^\/(_plugin\/kibana\/app|app)\/(dashboards|visu
 
 export const validateReport = async (
   client: ILegacyScopedClusterClient,
-  report: ReportSchemaType
+  report: ReportSchemaType,
+  basePath: String
 ) => {
+  report.query_url = report.query_url.replace(basePath, '');
+  report.report_definition.report_params.core_params.base_url = report.report_definition.report_params.core_params.base_url.replace(
+    basePath,
+    ''
+  );
   // validate basic schema
   report = reportSchema.validate(report);
   // parse to retrieve data
@@ -63,8 +69,13 @@ export const validateReport = async (
 
 export const validateReportDefinition = async (
   client: ILegacyScopedClusterClient,
-  reportDefinition: ReportDefinitionSchemaType
+  reportDefinition: ReportDefinitionSchemaType,
+  basePath: String
 ) => {
+  reportDefinition.report_params.core_params.base_url = reportDefinition.report_params.core_params.base_url.replace(
+    basePath,
+    ''
+  );
   // validate basic schema
   reportDefinition = reportDefinitionSchema.validate(reportDefinition);
   // parse to retrieve data


### PR DESCRIPTION
*Issue #, if available:*
#98
This is the most reported issue so far. Users are not able to generate any report if they have customized Kibana sever setting(host, sever base path, port), or enable TLS.

Server config is set in kibana.yml

*Description of changes:*
- remove the hardcoded `localhost:5601` when building the complete url
- Dynamically retrieve `serverInfo`(which contains `port`, `host`, `protocol`), and `server.basePath` and pass them through route handler for validating the input url, compose complete url.
- Add one more puppeteer launch option `ignoreHttpsError: true` to support TLS-enabled kibana server https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerlaunchoptions
- Add one more param "path: server.basePath" to the cookie object, to support customized server.basePath when security is enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
