### PR TITLE
turn off tenant selection panel by adding to local storage

### DIFF
--- a/kibana-reports/server/routes/lib/createReport.ts
+++ b/kibana-reports/server/routes/lib/createReport.ts
@@ -16,9 +16,8 @@
 import {
   REPORT_TYPE,
   REPORT_STATE,
-  LOCAL_HOST,
-  SECURITY_AUTH_COOKIE_NAME,
   DELIVERY_TYPE,
+  SECURITY_CONSTANTS,
 } from '../utils/constants';
 
 import {
@@ -105,7 +104,7 @@ export const createReport = async (
         const cookies = request.headers.cookie.split(';');
         cookies.map((item: string) => {
           const cookie = item.trim().split('=');
-          if (cookie[0] === SECURITY_AUTH_COOKIE_NAME) {
+          if (cookie[0] === SECURITY_CONSTANTS.AUTH_COOKIE_NAME) {
             cookieObject = {
               name: cookie[0],
               value: cookie[1],

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -75,7 +75,10 @@ export const DEFAULT_MAX_SIZE = 10000;
 
 export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 
-export const SECURITY_AUTH_COOKIE_NAME = 'security_authentication';
+export const SECURITY_CONSTANTS = {
+  AUTH_COOKIE_NAME: 'security_authentication',
+  TENANT_LOCAL_STORAGE_KEY: 'opendistro::security::tenant::show_popup',
+};
 
 export const CHROMIUM_PATH = `${__dirname}/../../../.chromium/headless_shell`;
 

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -91,6 +91,7 @@ export const createVisualReport = async (
   await page.goto(queryUrl, { waitUntil: 'networkidle0' });
   // should add to local storage after page.goto, then access the page again - browser must have an url to register local storage item on it
   await page.evaluate((key) => {
+    /* istanbul ignore next */
     localStorage.setItem(key, 'false');
   }, SECURITY_CONSTANTS.TENANT_LOCAL_STORAGE_KEY);
   await page.goto(queryUrl, { waitUntil: 'networkidle0' });

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -90,10 +90,13 @@ export const createVisualReport = async (
   logger.info(`original queryUrl ${queryUrl}`);
   await page.goto(queryUrl, { waitUntil: 'networkidle0' });
   // should add to local storage after page.goto, then access the page again - browser must have an url to register local storage item on it
-  await page.evaluate((key) => {
+  await page.evaluate(
     /* istanbul ignore next */
-    localStorage.setItem(key, 'false');
-  }, SECURITY_CONSTANTS.TENANT_LOCAL_STORAGE_KEY);
+    (key) => {
+      localStorage.setItem(key, 'false');
+    },
+    SECURITY_CONSTANTS.TENANT_LOCAL_STORAGE_KEY
+  );
   await page.goto(queryUrl, { waitUntil: 'networkidle0' });
   logger.info(`page url ${page.url()}`);
 

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -23,6 +23,7 @@ import {
   FORMAT,
   SELECTOR,
   CHROMIUM_PATH,
+  SECURITY_CONSTANTS,
 } from '../constants';
 import { getFileName } from '../helpers';
 import { CreateReportResultType } from '../types';
@@ -87,6 +88,11 @@ export const createVisualReport = async (
     await page.setCookie(cookie);
   }
   logger.info(`original queryUrl ${queryUrl}`);
+  await page.goto(queryUrl, { waitUntil: 'networkidle0' });
+  // should add to local storage after page.goto, then access the page again - browser must have an url to register local storage item on it
+  await page.evaluate((key) => {
+    localStorage.setItem(key, 'false');
+  }, SECURITY_CONSTANTS.TENANT_LOCAL_STORAGE_KEY);
   await page.goto(queryUrl, { waitUntil: 'networkidle0' });
   logger.info(`page url ${page.url()}`);
 


### PR DESCRIPTION
*Issue #, if available:*
#311
*Description of changes:*

Since the tenant info is already included in the cookie. There's no problem accessing the dashboard page. It's just the tenant selection panel we need to turn off, by setting the localstorage key value pair while using puppeteer to access page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
