### PR TITLE
add global tenant for report definition urls

### DIFF
--- a/kibana-reports/server/routes/utils/converters/backendToUi.ts
+++ b/kibana-reports/server/routes/utils/converters/backendToUi.ts
@@ -222,12 +222,15 @@ const getUiQueryUrl = (
   const timeFrom = moment(beginTimeMs).toISOString();
   const timeTo = moment(endTimeMs).toISOString();
   let queryUrl = `${baseUrl}?_g=(time:(from:'${timeFrom}',to:'${timeTo}'))`;
-  if (tenant) {
-    if (tenant === '__user__') {
+  if (tenant !== undefined) {
+    if (tenant === '') {
+      tenant = 'global';
+    } else if (tenant === '__user__') {
       tenant = 'private';
     }
     queryUrl = addTenantToURL(queryUrl, tenant);
   }
+
   return queryUrl;
 };
 


### PR DESCRIPTION
*Issue #, if available:*
on-demand report definition still renders the tenant panel
*Description of changes:*
add condtion to check global tenant and add to url

TODO: 
1. remove the old fix where we add the key-value pair to browser loacal storage
2. See if we can get rid of the addTenantToUrl logic from UI side. Only using the tenant info from ES backend.
3. Currently there's no way to distinguish global tenant and non-security from tenant field returned by backend. As they both are empty string.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.