### PR TITLE
passing default proxy-authentication headers

### DIFF
--- a/kibana-reports/server/routes/lib/createReport.ts
+++ b/kibana-reports/server/routes/lib/createReport.ts
@@ -115,13 +115,13 @@ export const createReport = async (
         });
       }
       // If header exists assuming that it needs forwarding
-      let AdditionalHeaders: Headers | undefined;
+      let additionalHeaders: Headers | undefined;
       if (request.headers[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER]) {
-        AdditionalHeaders = {}
-        AdditionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER];
-        AdditionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_IP_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_IP_HEADER];
+        additionalHeaders = {}
+        additionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER];
+        additionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_IP_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_IP_HEADER];
         if (request.headers[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER]) {
-          AdditionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER]
+          additionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER]
         }
       }
       const [value, release] = await semaphore.acquire();
@@ -131,7 +131,7 @@ export const createReport = async (
           completeQueryUrl,
           logger,
           cookieObject,
-          AdditionalHeaders,
+          additionalHeaders,
           timezone
         );
       } finally {

--- a/kibana-reports/server/routes/lib/createReport.ts
+++ b/kibana-reports/server/routes/lib/createReport.ts
@@ -30,7 +30,7 @@ import { createSavedSearchReport } from '../utils/savedSearchReportHelper';
 import { ReportSchemaType } from '../../model';
 import { CreateReportResultType } from '../utils/types';
 import { createVisualReport } from '../utils/visual_report/visualReportHelper';
-import { SetCookie } from 'puppeteer-core';
+import { SetCookie, Headers } from 'puppeteer-core';
 import { deliverReport } from './deliverReport';
 import { updateReportState } from './updateReportState';
 import { saveReport } from './saveReport';
@@ -114,6 +114,16 @@ export const createReport = async (
           }
         });
       }
+      // If header exists assuming that it needs forwarding
+      let AdditionalHeaders: Headers | undefined;
+      if (request.headers[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER]) {
+        AdditionalHeaders = {}
+        AdditionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_USER_HEADER];
+        AdditionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_IP_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_IP_HEADER];
+        if (request.headers[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER]) {
+          AdditionalHeaders[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER] = request.headers[SECURITY_CONSTANTS.PROXY_AUTH_ROLES_HEADER]
+        }
+      }
       const [value, release] = await semaphore.acquire();
       try {
         createReportResult = await createVisualReport(
@@ -121,6 +131,7 @@ export const createReport = async (
           completeQueryUrl,
           logger,
           cookieObject,
+          AdditionalHeaders,
           timezone
         );
       } finally {

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -78,6 +78,9 @@ export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 export const SECURITY_CONSTANTS = {
   AUTH_COOKIE_NAME: 'security_authentication',
   TENANT_LOCAL_STORAGE_KEY: 'opendistro::security::tenant::show_popup',
+  PROXY_AUTH_USER_HEADER: 'x-proxy-user',
+  PROXY_AUTH_ROLES_HEADER: 'x-proxy-roles',
+  PROXY_AUTH_IP_HEADER: 'x-forwarded-for',
 };
 
 export const CHROMIUM_PATH = `${__dirname}/../../../.chromium/headless_shell`;

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import puppeteer, { ElementHandle, SetCookie } from 'puppeteer-core';
+import puppeteer, { ElementHandle, SetCookie, Headers } from 'puppeteer-core';
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
 import { Logger } from '../../../../../../src/core/server';
@@ -36,6 +36,7 @@ export const createVisualReport = async (
   queryUrl: string,
   logger: Logger,
   cookie?: SetCookie,
+  additionalheaders?: Headers,
   timezone?: string
 ): Promise<CreateReportResultType> => {
   const {
@@ -86,6 +87,10 @@ export const createVisualReport = async (
   if (cookie) {
     logger.info('domain enables security, use session cookie to access');
     await page.setCookie(cookie);
+  }
+  if (additionalheaders) {
+    logger.info('domain passed proxy auth headers, passing to backend');
+    await page.setExtraHTTPHeaders(additionalheaders);
   }
   logger.info(`original queryUrl ${queryUrl}`);
   await page.goto(queryUrl, { waitUntil: 'networkidle0' });


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/kibana-reports/issues/328

*Description of changes:*

Passing the x-proxy-user,x-forwarded-for and x-proxy-roles headers though to puppeteer if they exist.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.