### PR TITLE
Add Notebooks as Report Source Option

### DIFF
--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -222,6 +222,7 @@ export function CreateReport(props) {
   ) => {
     const { httpClient } = props;
     //TODO: need better handle
+    console.log('metadata for creating new definition is', metadata);
     if (
       metadata.trigger.trigger_type === 'On demand' &&
       metadata.trigger.trigger_params !== undefined

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -222,7 +222,6 @@ export function CreateReport(props) {
   ) => {
     const { httpClient } = props;
     //TODO: need better handle
-    console.log('metadata for creating new definition is', metadata);
     if (
       metadata.trigger.trigger_type === 'On demand' &&
       metadata.trigger.trigger_params !== undefined

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
@@ -184,6 +184,25 @@ exports[`<ReportSettings /> panel dashboard create from in-context 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -284,70 +303,53 @@ exports[`<ReportSettings /> panel dashboard create from in-context 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -356,85 +358,104 @@ exports[`<ReportSettings /> panel dashboard create from in-context 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
                         <div
-                          class="euiPopover__anchor"
+                          class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
                         >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--start"
-                            data-test-subj="superDatePickerstartDatePopoverButton"
-                            title="2020-10-26T20:52:56.382Z"
+                          <div
+                            class="euiPopover__anchor"
                           >
-                            Oct 26, 2020 @ 13:52:56.382
-                          </button>
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--start"
+                              data-test-subj="superDatePickerstartDatePopoverButton"
+                              title="2020-10-26T20:52:56.382Z"
+                            >
+                              Oct 26, 2020 @ 13:52:56.382
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                      <div
-                        class="euiText euiText--small euiDatePickerRange__delimeter"
-                      >
                         <div
-                          class="euiTextColor euiTextColor--subdued"
+                          class="euiText euiText--small euiDatePickerRange__delimeter"
                         >
-                          →
-                        </div>
-                      </div>
-                      <div
-                        class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
-                      >
-                        <div
-                          class="euiPopover__anchor"
-                        >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--end"
-                            data-test-subj="superDatePickerendDatePopoverButton"
-                            title="2020-10-27T20:52:56.384Z"
+                          <div
+                            class="euiTextColor euiTextColor--subdued"
                           >
-                            Oct 27, 2020 @ 13:52:56.384
-                          </button>
+                            →
+                          </div>
+                        </div>
+                        <div
+                          class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
+                        >
+                          <div
+                            class="euiPopover__anchor"
+                          >
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--end"
+                              data-test-subj="superDatePickerendDatePopoverButton"
+                              title="2020-10-27T20:52:56.384Z"
+                            >
+                              Oct 27, 2020 @ 13:52:56.384
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -1276,6 +1297,25 @@ exports[`<ReportSettings /> panel display errors on create 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -1376,70 +1416,53 @@ exports[`<ReportSettings /> panel display errors on create 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="true"
-              class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="true"
+                class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -1448,92 +1471,111 @@ exports[`<ReportSettings /> panel display errors on create 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
                         <div
-                          class="euiPopover__anchor"
+                          class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
                         >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--start"
-                            data-test-subj="superDatePickerstartDatePopoverButton"
-                            title="2020-10-26T20:52:56.382Z"
+                          <div
+                            class="euiPopover__anchor"
                           >
-                            Oct 26, 2020 @ 13:52:56.382
-                          </button>
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--start"
+                              data-test-subj="superDatePickerstartDatePopoverButton"
+                              title="2020-10-26T20:52:56.382Z"
+                            >
+                              Oct 26, 2020 @ 13:52:56.382
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                      <div
-                        class="euiText euiText--small euiDatePickerRange__delimeter"
-                      >
                         <div
-                          class="euiTextColor euiTextColor--subdued"
+                          class="euiText euiText--small euiDatePickerRange__delimeter"
                         >
-                          →
-                        </div>
-                      </div>
-                      <div
-                        class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
-                      >
-                        <div
-                          class="euiPopover__anchor"
-                        >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--end"
-                            data-test-subj="superDatePickerendDatePopoverButton"
-                            title="2020-10-27T20:52:56.384Z"
+                          <div
+                            class="euiTextColor euiTextColor--subdued"
                           >
-                            Oct 27, 2020 @ 13:52:56.384
-                          </button>
+                            →
+                          </div>
+                        </div>
+                        <div
+                          class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
+                        >
+                          <div
+                            class="euiPopover__anchor"
+                          >
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--end"
+                              data-test-subj="superDatePickerendDatePopoverButton"
+                              title="2020-10-27T20:52:56.384Z"
+                            >
+                              Oct 27, 2020 @ 13:52:56.384
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              aria-live="polite"
-              class="euiFormErrorText euiFormRow__text"
-              id="random_html_id-error-0"
-            >
-              Invalid time range selected.
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                aria-live="polite"
+                class="euiFormErrorText euiFormRow__text"
+                id="random_html_id-error-0"
+              >
+                Invalid time range selected.
+              </div>
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -2375,6 +2417,25 @@ exports[`<ReportSettings /> panel render component 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -2470,65 +2531,53 @@ exports[`<ReportSettings /> panel render component 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium euiIcon-isLoading"
+                              class="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -2536,53 +2585,67 @@ exports[`<ReportSettings /> panel render component 1`] = `
                               width="16"
                               xmlns="http://www.w3.org/2000/svg"
                             />
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              />
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
-                      <button
-                        class="euiSuperDatePicker__prettyFormat"
-                        data-test-subj="superDatePickerShowDatesButton"
+                      <div
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
-                        Last 30 minutes
-                        <span
-                          class="euiSuperDatePicker__prettyFormatLink"
+                        <button
+                          class="euiSuperDatePicker__prettyFormat"
+                          data-test-subj="superDatePickerShowDatesButton"
                         >
-                          Show dates
-                        </span>
-                      </button>
+                          Last 30 minutes
+                          <span
+                            class="euiSuperDatePicker__prettyFormatLink"
+                          >
+                            Show dates
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -2893,6 +2956,26 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              disabled=""
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -2993,70 +3076,53 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -3065,57 +3131,76 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
-                      <button
-                        class="euiSuperDatePicker__prettyFormat"
-                        data-test-subj="superDatePickerShowDatesButton"
+                      <div
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
-                        Last 30 minutes
-                        <span
-                          class="euiSuperDatePicker__prettyFormatLink"
+                        <button
+                          class="euiSuperDatePicker__prettyFormat"
+                          data-test-subj="superDatePickerShowDatesButton"
                         >
-                          Show dates
-                        </span>
-                      </button>
+                          Last 30 minutes
+                          <span
+                            class="euiSuperDatePicker__prettyFormatLink"
+                          >
+                            Show dates
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -3426,6 +3511,26 @@ exports[`<ReportSettings /> panel render edit, dashboard source 2`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              disabled=""
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -3526,70 +3631,53 @@ exports[`<ReportSettings /> panel render edit, dashboard source 2`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -3598,57 +3686,76 @@ exports[`<ReportSettings /> panel render edit, dashboard source 2`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
-                      <button
-                        class="euiSuperDatePicker__prettyFormat"
-                        data-test-subj="superDatePickerShowDatesButton"
+                      <div
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
-                        Last 30 minutes
-                        <span
-                          class="euiSuperDatePicker__prettyFormatLink"
+                        <button
+                          class="euiSuperDatePicker__prettyFormat"
+                          data-test-subj="superDatePickerShowDatesButton"
                         >
-                          Show dates
-                        </span>
-                      </button>
+                          Last 30 minutes
+                          <span
+                            class="euiSuperDatePicker__prettyFormatLink"
+                          >
+                            Show dates
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -3959,6 +4066,26 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              disabled=""
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -4059,70 +4186,53 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -4131,57 +4241,76 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
-                      <button
-                        class="euiSuperDatePicker__prettyFormat"
-                        data-test-subj="superDatePickerShowDatesButton"
+                      <div
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
-                        Last 30 minutes
-                        <span
-                          class="euiSuperDatePicker__prettyFormatLink"
+                        <button
+                          class="euiSuperDatePicker__prettyFormat"
+                          data-test-subj="superDatePickerShowDatesButton"
                         >
-                          Show dates
-                        </span>
-                      </button>
+                          Last 30 minutes
+                          <span
+                            class="euiSuperDatePicker__prettyFormatLink"
+                          >
+                            Show dates
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -4492,6 +4621,26 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              disabled=""
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -4592,70 +4741,53 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -4664,57 +4796,76 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
-                      <button
-                        class="euiSuperDatePicker__prettyFormat"
-                        data-test-subj="superDatePickerShowDatesButton"
+                      <div
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
-                        Last 30 minutes
-                        <span
-                          class="euiSuperDatePicker__prettyFormatLink"
+                        <button
+                          class="euiSuperDatePicker__prettyFormat"
+                          data-test-subj="superDatePickerShowDatesButton"
                         >
-                          Show dates
-                        </span>
-                      </button>
+                          Last 30 minutes
+                          <span
+                            class="euiSuperDatePicker__prettyFormatLink"
+                          >
+                            Show dates
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -5025,6 +5176,26 @@ exports[`<ReportSettings /> panel render edit, visualization source 2`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              disabled=""
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -5125,70 +5296,53 @@ exports[`<ReportSettings /> panel render edit, visualization source 2`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -5197,57 +5351,76 @@ exports[`<ReportSettings /> panel render edit, visualization source 2`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
-                      <button
-                        class="euiSuperDatePicker__prettyFormat"
-                        data-test-subj="superDatePickerShowDatesButton"
+                      <div
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
-                        Last 30 minutes
-                        <span
-                          class="euiSuperDatePicker__prettyFormatLink"
+                        <button
+                          class="euiSuperDatePicker__prettyFormat"
+                          data-test-subj="superDatePickerShowDatesButton"
                         >
-                          Show dates
-                        </span>
-                      </button>
+                          Last 30 minutes
+                          <span
+                            class="euiSuperDatePicker__prettyFormatLink"
+                          >
+                            Show dates
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -5555,6 +5728,25 @@ exports[`<ReportSettings /> panel saved search create from in-context 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -5655,70 +5847,53 @@ exports[`<ReportSettings /> panel saved search create from in-context 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -5727,85 +5902,104 @@ exports[`<ReportSettings /> panel saved search create from in-context 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
                         <div
-                          class="euiPopover__anchor"
+                          class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
                         >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--start"
-                            data-test-subj="superDatePickerstartDatePopoverButton"
-                            title="2020-10-26T20:52:56.382Z"
+                          <div
+                            class="euiPopover__anchor"
                           >
-                            Oct 26, 2020 @ 13:52:56.382
-                          </button>
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--start"
+                              data-test-subj="superDatePickerstartDatePopoverButton"
+                              title="2020-10-26T20:52:56.382Z"
+                            >
+                              Oct 26, 2020 @ 13:52:56.382
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                      <div
-                        class="euiText euiText--small euiDatePickerRange__delimeter"
-                      >
                         <div
-                          class="euiTextColor euiTextColor--subdued"
+                          class="euiText euiText--small euiDatePickerRange__delimeter"
                         >
-                          →
-                        </div>
-                      </div>
-                      <div
-                        class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
-                      >
-                        <div
-                          class="euiPopover__anchor"
-                        >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--end"
-                            data-test-subj="superDatePickerendDatePopoverButton"
-                            title="2020-10-27T20:52:56.384Z"
+                          <div
+                            class="euiTextColor euiTextColor--subdued"
                           >
-                            Oct 27, 2020 @ 13:52:56.384
-                          </button>
+                            →
+                          </div>
+                        </div>
+                        <div
+                          class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
+                        >
+                          <div
+                            class="euiPopover__anchor"
+                          >
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--end"
+                              data-test-subj="superDatePickerendDatePopoverButton"
+                              title="2020-10-27T20:52:56.384Z"
+                            >
+                              Oct 27, 2020 @ 13:52:56.384
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>
@@ -6647,6 +6841,25 @@ exports[`<ReportSettings /> panel visualization create from in-context 1`] = `
               Saved search
             </label>
           </div>
+          <div
+            class="euiRadio euiRadioGroup__item"
+          >
+            <input
+              class="euiRadio__input"
+              id="notebooksReportSource"
+              type="radio"
+              value=""
+            />
+            <div
+              class="euiRadio__circle"
+            />
+            <label
+              class="euiRadio__label"
+              for="notebooksReportSource"
+            >
+              Notebooks
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -6747,70 +6960,53 @@ exports[`<ReportSettings /> panel visualization create from in-context 1`] = `
     </div>
     <div>
       <div>
-        <div
-          class="euiFormRow"
-          id="random_html_id-row"
-        >
+        <div>
           <div
-            class="euiFormRow__labelWrapper"
-          >
-            <label
-              aria-invalid="false"
-              class="euiFormLabel euiFormRow__label"
-              for="random_html_id"
-            >
-              Time range
-            </label>
-          </div>
-          <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormRow"
+            id="random_html_id-row"
           >
             <div
-              class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                Time range
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFlexItem"
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper euiSuperDatePicker__flexWrapper--noUpdateButton"
               >
                 <div
-                  class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
+                  class="euiFlexItem"
                 >
                   <div
-                    class="euiPopover euiPopover--anchorDownLeft"
-                    id="QuickSelectPopover"
+                    class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"
                   >
                     <div
-                      class="euiPopover__anchor euiQuickSelectPopover__anchor"
+                      class="euiPopover euiPopover--anchorDownLeft"
+                      id="QuickSelectPopover"
                     >
-                      <button
-                        aria-label="Date quick select"
-                        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
-                        data-test-subj="superDatePickerToggleQuickMenuButton"
-                        type="button"
+                      <div
+                        class="euiPopover__anchor euiQuickSelectPopover__anchor"
                       >
-                        <span
-                          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        <button
+                          aria-label="Date quick select"
+                          class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall euiFormControlLayout__prepend"
+                          data-test-subj="superDatePickerToggleQuickMenuButton"
+                          type="button"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiButtonContent__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                              fill-rule="non-zero"
-                            />
-                          </svg>
                           <span
-                            class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium"
+                              class="euiIcon euiIcon--medium euiButtonContent__icon"
                               focusable="false"
                               height="16"
                               role="img"
@@ -6819,85 +7015,104 @@ exports[`<ReportSettings /> panel visualization create from in-context 1`] = `
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
-                                fill-rule="evenodd"
+                                d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                fill-rule="non-zero"
                               />
                             </svg>
+                            <span
+                              class="euiButtonEmpty__text euiQuickSelectPopover__buttonText"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                      </button>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
-                  >
                     <div
-                      class="euiDatePickerRange euiDatePickerRange--inGroup"
+                      class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
+                        class="euiDatePickerRange euiDatePickerRange--inGroup"
                       >
                         <div
-                          class="euiPopover__anchor"
+                          class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiSuperDatePicker__startPopoverButton"
                         >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--start"
-                            data-test-subj="superDatePickerstartDatePopoverButton"
-                            title="2020-10-26T20:52:56.382Z"
+                          <div
+                            class="euiPopover__anchor"
                           >
-                            Oct 26, 2020 @ 13:52:56.382
-                          </button>
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--start"
+                              data-test-subj="superDatePickerstartDatePopoverButton"
+                              title="2020-10-26T20:52:56.382Z"
+                            >
+                              Oct 26, 2020 @ 13:52:56.382
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                      <div
-                        class="euiText euiText--small euiDatePickerRange__delimeter"
-                      >
                         <div
-                          class="euiTextColor euiTextColor--subdued"
+                          class="euiText euiText--small euiDatePickerRange__delimeter"
                         >
-                          →
-                        </div>
-                      </div>
-                      <div
-                        class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
-                      >
-                        <div
-                          class="euiPopover__anchor"
-                        >
-                          <button
-                            class="euiDatePopoverButton euiDatePopoverButton--end"
-                            data-test-subj="superDatePickerendDatePopoverButton"
-                            title="2020-10-27T20:52:56.384Z"
+                          <div
+                            class="euiTextColor euiTextColor--subdued"
                           >
-                            Oct 27, 2020 @ 13:52:56.384
-                          </button>
+                            →
+                          </div>
+                        </div>
+                        <div
+                          class="euiPopover euiPopover--anchorDownRight euiPopover--displayBlock"
+                        >
+                          <div
+                            class="euiPopover__anchor"
+                          >
+                            <button
+                              class="euiDatePopoverButton euiDatePopoverButton--end"
+                              data-test-subj="superDatePickerendDatePopoverButton"
+                              title="2020-10-27T20:52:56.384Z"
+                            >
+                              Oct 27, 2020 @ 13:52:56.384
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="euiFormHelpText euiFormRow__text"
-              id="random_html_id-help"
-            >
-              Time range is relative to the report creation date on the report trigger.
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help"
+              >
+                Time range is relative to the report creation date on the report trigger.
+              </div>
             </div>
           </div>
         </div>
+        <div>
+          <div
+            aria-live="polite"
+            class="euiGlobalToastList euiGlobalToastList--right"
+            role="region"
+          />
+        </div>
       </div>
-      <div>
-        <div
-          aria-live="polite"
-          class="euiGlobalToastList euiGlobalToastList--right"
-          role="region"
-        />
-      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
     </div>
-    <div
-      class="euiSpacer euiSpacer--l"
-    />
     <div>
       <div>
         <div>

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/__snapshots__/report_settings.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`<ReportSettings /> panel dashboard create from in-context 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -1313,7 +1313,7 @@ exports[`<ReportSettings /> panel display errors on create 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -2433,7 +2433,7 @@ exports[`<ReportSettings /> panel render component 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -2973,7 +2973,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -3528,7 +3528,7 @@ exports[`<ReportSettings /> panel render edit, dashboard source 2`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -4083,7 +4083,7 @@ exports[`<ReportSettings /> panel render edit, saved search source 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -4638,7 +4638,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -5193,7 +5193,7 @@ exports[`<ReportSettings /> panel render edit, visualization source 2`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -5744,7 +5744,7 @@ exports[`<ReportSettings /> panel saved search create from in-context 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>
@@ -6857,7 +6857,7 @@ exports[`<ReportSettings /> panel visualization create from in-context 1`] = `
               class="euiRadio__label"
               for="notebooksReportSource"
             >
-              Notebooks
+              Notebook
             </label>
           </div>
         </div>

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings.test.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings.test.tsx
@@ -64,6 +64,9 @@ const dashboardHits = {
           timeTo: 'now',
           title: 'Mock Dashboard',
         },
+        notebook: {
+          name: 'mock notebook name'
+        }
       },
     },
   ],
@@ -78,6 +81,9 @@ const visualizationHits = {
           description: 'mock visualization value',
           title: 'Mock Visualization',
         },
+        notebook: {
+          name: 'mock notebook name'
+        },
       },
     },
   ],
@@ -90,6 +96,9 @@ const savedSearchHits = {
       _source: {
         search: {
           title: 'Mock saved search value',
+        },
+        notebook: {
+          name: 'mock notebook name'
         },
       },
     },

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings_helpers.test.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings_helpers.test.tsx
@@ -16,6 +16,8 @@
 import {
   getDashboardBaseUrlCreate,
   getDashboardOptions,
+  getNotebooksBaseUrlCreate,
+  getNotebooksOptions,
   getSavedSearchBaseUrlCreate,
   getSavedSearchOptions,
   getVisualizationBaseUrlCreate,
@@ -101,6 +103,14 @@ describe('report_settings_helpers tests', () => {
   test('getSavedSearchBaseUrlCreate not from in-context', () => {
     const baseUrl = getSavedSearchBaseUrlCreate(false, TEST_DEFINITION_ID, false);
     expect(baseUrl).toBe('/');
+  });
+
+  test('getNotebookBaseUrlCreate', () => {
+    const baseUrl = getNotebooksBaseUrlCreate(true, TEST_DEFINITION_ID, true);
+    expect(baseUrl).toBe('/app/opendistro-notebooks-kibana#/');
+
+    const baseUrlNotFromEdit = getNotebooksBaseUrlCreate(false, TEST_DEFINITION_ID, true);
+    expect('/app/opendistro-notebooks-kibana#/')
   })
 
   test('getDashboardOptions', () => {
@@ -151,6 +161,22 @@ describe('report_settings_helpers tests', () => {
     const options = getSavedSearchOptions(mockData);
     expect(options[0].value).toBe('1234567890abcdefghijk');
     expect(options[0].label).toBe('Mock saved search title');
+  });
+
+  test('getNotebooksOptions', () => {
+    const mockData = [
+      {
+        _id: 'abcdefgh1234',
+        _source: {
+          notebook: {
+            name: 'Mock notebook name'
+          }
+        }
+      }
+    ];
+    const options = getNotebooksOptions(mockData);
+    expect(options[0].value).toBe('abcdefgh1234');
+    expect(options[0].label).toBe('Mock notebook name');
   });
 
   test('handleDataToVisualReportSourceChange', () => {

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings_helpers.test.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings_helpers.test.tsx
@@ -166,12 +166,8 @@ describe('report_settings_helpers tests', () => {
   test('getNotebooksOptions', () => {
     const mockData = [
       {
-        _id: 'abcdefgh1234',
-        _source: {
-          notebook: {
-            name: 'Mock notebook name'
-          }
-        }
+        id: 'abcdefgh1234',
+        path: 'Mock notebook name'
       }
     ];
     const options = getNotebooksOptions(mockData);

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -597,10 +597,22 @@ export function ReportSettings(props: ReportSettingProps) {
       .catch((error) => {
         console.log('error when fetching saved searches:', error);
       });
+
+      /**
+       *   fetchNotebooks = () => {
+    return this.props.http
+      .get(`${API_PREFIX}/`)
+      .then((res) => this.setState(res))
+      .catch((err) => {
+        console.error('Issue in fetching the notebooks', err.body.message);
+      });
+  };
+       */
     
     await httpClientProps
-      .get('../api/reporting/getReportSource/notebooks')
-      .then(async (response: { [x: string]: { [x: string]: string | any[]; }; }) => {
+      .get('/api/notebooks/')
+      .then(async (response: any) => {
+        console.log('response is', response);
         let notebooksOptions = getNotebooksOptions(response['hits']['hits']);
         reportSourceOptions.notebooks = notebooksOptions;
         await handleNotebooks(notebooksOptions);

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -597,23 +597,11 @@ export function ReportSettings(props: ReportSettingProps) {
       .catch((error) => {
         console.log('error when fetching saved searches:', error);
       });
-
-      /**
-       *   fetchNotebooks = () => {
-    return this.props.http
-      .get(`${API_PREFIX}/`)
-      .then((res) => this.setState(res))
-      .catch((err) => {
-        console.error('Issue in fetching the notebooks', err.body.message);
-      });
-  };
-       */
     
     await httpClientProps
       .get('/api/notebooks/')
       .then(async (response: any) => {
-        console.log('response is', response);
-        let notebooksOptions = getNotebooksOptions(response['hits']['hits']);
+        let notebooksOptions = getNotebooksOptions(response.data);
         reportSourceOptions.notebooks = notebooksOptions;
         await handleNotebooks(notebooksOptions);
       })

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -721,6 +721,21 @@ export function ReportSettings(props: ReportSettingProps) {
       )
     ): null;
 
+  const displayTimeRangeSelect = 
+    reportSourceId != 'notebooksReportSource' ? (
+      <div>
+        <TimeRangeSelect
+          timeRange={timeRange}
+          reportDefinitionRequest={reportDefinitionRequest}
+          edit={edit}
+          id={editDefinitionId}
+          httpClientProps={httpClientProps}
+          showTimeRangeError={showTimeRangeError}
+        />
+        <EuiSpacer />
+      </div>
+    ): null;
+
   const displayVisualReportsFormatAndMarkdown =
     reportSourceId != 'savedSearchReportSource' ? (
       <div>
@@ -793,15 +808,7 @@ export function ReportSettings(props: ReportSettingProps) {
         {displayVisualizationSelect}
         {displaySavedSearchSelect}
         {displayNotebooksSelect}
-        <TimeRangeSelect
-          timeRange={timeRange}
-          reportDefinitionRequest={reportDefinitionRequest}
-          edit={edit}
-          id={editDefinitionId}
-          httpClientProps={httpClientProps}
-          showTimeRangeError={showTimeRangeError}
-        />
-        <EuiSpacer />
+        {displayTimeRangeSelect}
         {displayVisualReportsFormatAndMarkdown}
       </EuiPageContentBody>
     </EuiPageContent>

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -512,7 +512,7 @@ export function ReportSettings(props: ReportSettingProps) {
     }
   };
 
-  const setDefaultEditValues = async (response, reportSourceOptions) => {
+  const setDefaultEditValues = async (response, reportSourceOptions) => {    
     setReportName(response.report_definition.report_params.report_name);
     setReportDescription(response.report_definition.report_params.description);
     reportDefinitionRequest.report_params.report_name =
@@ -605,6 +605,9 @@ export function ReportSettings(props: ReportSettingProps) {
         let notebooksOptions = getNotebooksOptions(response['hits']['hits']);
         reportSourceOptions.notebooks = notebooksOptions;
         await handleNotebooks(notebooksOptions);
+      })
+      .catch((error) => {
+        console.log('error when fetching notebooks:', error);
       })
     return reportSourceOptions;
   };

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -60,7 +60,6 @@ import {
 import { TimeRangeSelect } from './time_range';
 import { converter } from '../utils';
 import { ReportDefinitionSchemaType } from 'server/model';
-import { convertSavedDashboardPanelToPanelState } from '../../../../../../src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters';
 
 type ReportSettingProps = {
   edit: boolean;

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -54,10 +54,13 @@ import {
   getDashboardBaseUrlCreate,
   getDashboardOptions,
   handleDataToVisualReportSourceChange,
+  getNotebooksOptions,
+  getNotebooksBaseUrlCreate,
 } from './report_settings_helpers';
 import { TimeRangeSelect } from './time_range';
 import { converter } from '../utils';
 import { ReportDefinitionSchemaType } from 'server/model';
+import { convertSavedDashboardPanelToPanelState } from '../../../../../../src/plugins/dashboard/public/application/lib/embeddable_saved_object_converters';
 
 type ReportSettingProps = {
   edit: boolean;
@@ -99,6 +102,9 @@ export function ReportSettings(props: ReportSettingProps) {
   const [savedSearchSourceSelect, setSavedSearchSourceSelect] = useState([] as any);
   const [savedSearches, setSavedSearches] = useState([] as any);
 
+  const [notebooksSourceSelect, setNotebooksSourceSelect] = useState([] as any);
+  const [notebooks, setNotebooks] = useState([] as any);
+
   const [fileFormat, setFileFormat] = useState('pdf');
 
   const handleDashboards = (e) => {
@@ -112,6 +118,10 @@ export function ReportSettings(props: ReportSettingProps) {
   const handleSavedSearches = (e) => {
     setSavedSearches(e);
   };
+
+  const handleNotebooks = (e) => {
+    setNotebooks(e);
+  }
 
   const handleReportName = (e: {
     target: { value: React.SetStateAction<string> };
@@ -161,6 +171,15 @@ export function ReportSettings(props: ReportSettingProps) {
       reportDefinitionRequest.report_params.core_params.report_format = 'csv';
       reportDefinitionRequest.report_params.core_params.limit = 10000;
       reportDefinitionRequest.report_params.core_params.excel = true;
+    } else if (e === 'notebooksReportSource') {
+      reportDefinitionRequest.report_params.report_source = 'Notebook';
+      reportDefinitionRequest.report_params.core_params.base_url = 
+        getNotebooksBaseUrlCreate(edit, editDefinitionId, fromInContext) + 
+        notebooks[0].value;
+      
+      // set params to visual report params after switch from saved search
+      handleDataToVisualReportSourceChange(reportDefinitionRequest);
+      setFileFormat('pdf');
     }
   };
 
@@ -217,6 +236,22 @@ export function ReportSettings(props: ReportSettingProps) {
       reportDefinitionRequest.report_params.core_params.base_url = "";
     }
   };
+
+  const handleNotebooksSelect = (e) => {
+    setNotebooksSourceSelect(e);
+    let fromInContext = false;
+    if (window.location.href.includes('?')) {
+      fromInContext = true;
+    }
+    if (e.length > 0) {
+      reportDefinitionRequest.report_params.core_params.base_url =
+        getNotebooksBaseUrlCreate(edit, editDefinitionId, fromInContext) + 
+        e[0].value;
+    }
+    else {
+      reportDefinitionRequest.report_params.core_params.base_url = "";
+    }
+  }
 
   const handleFileFormat = (e: React.SetStateAction<string>) => {
     setFileFormat(e);
@@ -521,6 +556,7 @@ export function ReportSettings(props: ReportSettingProps) {
       dashboard: [],
       visualizations: [],
       savedSearch: [],
+      notebooks: []
     };
     reportDefinitionRequest.report_params.core_params.report_format = fileFormat;
     await httpClientProps
@@ -562,6 +598,14 @@ export function ReportSettings(props: ReportSettingProps) {
       .catch((error) => {
         console.log('error when fetching saved searches:', error);
       });
+    
+    await httpClientProps
+      .get('../api/reporting/getReportSource/notebooks')
+      .then(async (response: { [x: string]: { [x: string]: string | any[]; }; }) => {
+        let notebooksOptions = getNotebooksOptions(response['hits']['hits']);
+        reportSourceOptions.notebooks = notebooksOptions;
+        await handleNotebooks(notebooksOptions);
+      })
     return reportSourceOptions;
   };
 
@@ -654,6 +698,29 @@ export function ReportSettings(props: ReportSettingProps) {
       )
     ) : null;
 
+  const displayNotebooksSelect = 
+    reportSourceId === 'notebooksReportSource' ? (
+      (
+        <div>
+          <EuiFormRow
+            label="Select notebook"
+            isInvalid={showSettingsReportSourceError}
+            error={settingsReportSourceErrorMessage}
+          >
+            <EuiComboBox
+              id="reportSourceNotebooksSelect"
+              placeholder="Select a notebook"
+              singleSelection={{ asPlainText: true }}
+              options={notebooks}
+              onChange={handleNotebooksSelect}
+              selectedOptions={notebooksSourceSelect}
+            />
+          </EuiFormRow>
+          <EuiSpacer />
+        </div>
+      )
+    ): null;
+
   const displayVisualReportsFormatAndMarkdown =
     reportSourceId != 'savedSearchReportSource' ? (
       <div>
@@ -725,6 +792,7 @@ export function ReportSettings(props: ReportSettingProps) {
         {displayDashboardSelect}
         {displayVisualizationSelect}
         {displaySavedSearchSelect}
+        {displayNotebooksSelect}
         <TimeRangeSelect
           timeRange={timeRange}
           reportDefinitionRequest={reportDefinitionRequest}

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -26,6 +26,10 @@ export const REPORT_SOURCE_RADIOS = [
     id: 'savedSearchReportSource',
     label: 'Saved search',
   },
+  {
+    id: 'notebooksReportSource',
+    label: 'Notebooks'
+  }
 ];
 
 export const PDF_PNG_FILE_FORMAT_OPTIONS = [
@@ -64,6 +68,7 @@ export const REPORT_SOURCE_TYPES = {
   dashboard: 'Dashboard',
   visualization: 'Visualization',
   savedSearch: 'Saved search',
+  notebook: 'Notebook'
 };
 
 export const commonTimeRanges = [

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -28,7 +28,7 @@ export const REPORT_SOURCE_RADIOS = [
   },
   {
     id: 'notebooksReportSource',
-    label: 'Notebooks'
+    label: 'Notebook'
   }
 ];
 

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -100,6 +100,31 @@ export const getSavedSearchBaseUrlCreate = (
   );
 };
 
+export const getNotebooksBaseUrlCreate = (
+  edit: boolean,
+  editDefinitionId: string,
+  fromInContext: boolean
+) => {
+  let baseUrl;
+  if (!fromInContext) {
+    baseUrl = location.pathname + location.hash;
+  } else {
+    baseUrl = '/app/opendistro-notebooks-kibana#/';
+  }
+  if (edit) {
+    return baseUrl.replace(
+      `opendistro_kibana_reports#/edit/${editDefinitionId}`,
+      'opendistro-notebooks-kibana#/'
+    );
+  } else if (fromInContext) {
+    return baseUrl;
+  }
+  return baseUrl.replace(
+    'opendistro_kibana_reports#/create',
+    'opendistro-notebooks-kibana#/'
+  );
+}
+
 export const getDashboardOptions = (data) => {
   let index;
   let dashboard_options = [];
@@ -138,6 +163,19 @@ export const getSavedSearchOptions = (data: string | any[]) => {
   }
   return options;
 };
+
+export const getNotebooksOptions = (data: string | any[]) => {
+  let index;
+  let options = [];
+  for (index = 0; index < data.length; ++index) {
+    let entry = {
+      value: data[index]['_id'],
+      label: data[index]['_source']['notebook']['name']
+    }
+    options.push(entry);
+  }
+  return options;
+}
 
 export const handleDataToVisualReportSourceChange = (
   reportDefinitionRequest

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_helpers.tsx
@@ -164,13 +164,13 @@ export const getSavedSearchOptions = (data: string | any[]) => {
   return options;
 };
 
-export const getNotebooksOptions = (data: string | any[]) => {
+export const getNotebooksOptions = (data: any) => {
   let index;
   let options = [];
   for (index = 0; index < data.length; ++index) {
     let entry = {
-      value: data[index]['_id'],
-      label: data[index]['_source']['notebook']['name']
+      value: data[index]['id'],
+      label: data[index]['path']
     }
     options.push(entry);
   }

--- a/kibana-reports/server/model/backendModel.ts
+++ b/kibana-reports/server/model/backendModel.ts
@@ -99,6 +99,7 @@ export enum BACKEND_REPORT_SOURCE {
   dashboard = 'Dashboard',
   visualization = 'Visualization',
   savedSearch = 'SavedSearch',
+  notebook = 'Notebook'
 }
 
 export enum BACKEND_REPORT_STATE {
@@ -132,6 +133,7 @@ export const REPORT_SOURCE_DICT = {
   [REPORT_TYPE.dashboard]: BACKEND_REPORT_SOURCE.dashboard,
   [REPORT_TYPE.visualization]: BACKEND_REPORT_SOURCE.visualization,
   [REPORT_TYPE.savedSearch]: BACKEND_REPORT_SOURCE.savedSearch,
+  [REPORT_TYPE.notebook]: BACKEND_REPORT_SOURCE.notebook
 };
 
 export const REPORT_FORMAT_DICT = {
@@ -155,4 +157,5 @@ export const URL_PREFIX_DICT = {
   [BACKEND_REPORT_SOURCE.dashboard]: '/app/dashboards#/view/',
   [BACKEND_REPORT_SOURCE.savedSearch]: '/app/discover#/view/',
   [BACKEND_REPORT_SOURCE.visualization]: '/app/visualize#/edit/',
+  [BACKEND_REPORT_SOURCE.notebook]: '/app/opendistro-notebooks-kibana#/'
 };

--- a/kibana-reports/server/model/index.ts
+++ b/kibana-reports/server/model/index.ts
@@ -200,6 +200,7 @@ export const reportParamsSchema = schema.object({
     schema.literal(REPORT_TYPE.dashboard),
     schema.literal(REPORT_TYPE.visualization),
     schema.literal(REPORT_TYPE.savedSearch),
+    schema.literal(REPORT_TYPE.notebook)
   ]),
   description: schema.string(),
   core_params: schema.conditional(

--- a/kibana-reports/server/routes/lib/createReport.ts
+++ b/kibana-reports/server/routes/lib/createReport.ts
@@ -67,7 +67,6 @@ export const createReport = async (
 
   let createReportResult: CreateReportResultType;
   let reportId;
-
   const {
     report_definition: {
       report_params: reportParams,
@@ -92,7 +91,7 @@ export const createReport = async (
         isScheduledTask
       );
     } else {
-      // report source can only be one of [saved search, visualization, dashboard]
+      // report source can only be one of [saved search, visualization, dashboard, notebook]
       // compose url
       const relativeUrl = report.query_url.startsWith(basePath)
         ? report.query_url

--- a/kibana-reports/server/routes/report.ts
+++ b/kibana-reports/server/routes/report.ts
@@ -217,7 +217,6 @@ export default function (router: IRouter, accessInfo: AccessInfoType) {
           reportId
         );
         addToMetric('report', 'create_from_definition', 'count', report);
-
         return response.ok({
           body: {
             data: reportData.dataUrl,

--- a/kibana-reports/server/routes/reportDefinition.ts
+++ b/kibana-reports/server/routes/reportDefinition.ts
@@ -177,6 +177,7 @@ export default function (router: IRouter, accessInfo: AccessInfoType) {
           request
         );
 
+
         const esResp = await esReportsClient.callAsCurrentUser(
           'es_reports.getReportDefinitions',
           {
@@ -184,6 +185,7 @@ export default function (router: IRouter, accessInfo: AccessInfoType) {
             maxItems: maxItems || DEFAULT_MAX_SIZE,
           }
         );
+
 
         const reportDefinitionsList = backendToUiReportDefinitionsList(
           esResp.reportDefinitionDetailsList,

--- a/kibana-reports/server/routes/reportSource.ts
+++ b/kibana-reports/server/routes/reportSource.ts
@@ -62,6 +62,12 @@ export default function (router: IRouter) {
           size: DEFAULT_MAX_SIZE,
         };
         responseParams = params;
+      } else if (request.params.reportSourceType === 'notebooks') {
+        const params: RequestParams.Search = {
+          index: '.opendistro-notebooks',
+          size: DEFAULT_MAX_SIZE,
+        };
+        responseParams = params;
       }
       try {
         const esResp = await context.core.elasticsearch.legacy.client.callAsCurrentUser(

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -69,6 +69,7 @@ export enum DELIVERY_TYPE {
 export enum SELECTOR {
   dashboard = '#dashboardViewport',
   visualization = '.visEditor__content',
+  notebook = '.euiPageBody'
 }
 
 // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-from-size.html
@@ -157,6 +158,18 @@ export const GLOBAL_BASIC_COUNTER: CountersType = {
       },
     },
   },
+  notebook: {
+    pdf: {
+      download: {
+        count: 0,
+      },
+    },
+    png: {
+      download: {
+        count: 0,
+      },
+    },
+  },
   saved_search: {
     csv: {
       download: {
@@ -241,6 +254,18 @@ export const DEFAULT_ROLLING_COUNTER: CountersType = {
     },
   },
   visualization: {
+    pdf: {
+      download: {
+        count: 0,
+      },
+    },
+    png: {
+      download: {
+        count: 0,
+      },
+    },
+  },
+  notebook: {
     pdf: {
       download: {
         count: 0,

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -49,6 +49,7 @@ export enum REPORT_TYPE {
   savedSearch = 'Saved search',
   dashboard = 'Dashboard',
   visualization = 'Visualization',
+  notebook = 'Notebook'
 }
 
 export enum DATA_REPORT_CONFIG {

--- a/kibana-reports/server/routes/utils/metricHelper.ts
+++ b/kibana-reports/server/routes/utils/metricHelper.ts
@@ -40,10 +40,8 @@ export const addToMetric = (
   const count = 1;
   // remove outdated key-value pairs
   trim();
-
   const timeKey = getKey(Date.now());
   const rollingCounters = time2CountWin.get(timeKey);
-
   time2CountWin.set(
     timeKey,
     updateCounters(

--- a/kibana-reports/server/routes/utils/types.ts
+++ b/kibana-reports/server/routes/utils/types.ts
@@ -19,7 +19,7 @@ export interface CreateReportResultType {
   fileName: string;
 }
 
-type ReportSourceType = 'dashboard' | 'visualization' | 'saved_search';
+type ReportSourceType = 'dashboard' | 'visualization' | 'saved_search' | 'notebook';
 type ReportFormatType = 'pdf' | 'png' | 'csv';
 type UsageActionType = 'download';
 export type EntityType = 'report' | 'report_definition' | 'report_source';

--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -158,12 +158,16 @@ export const createVisualReport = async (
         visible: true,
       });
       break;
+    case REPORT_TYPE.notebook:
+      await page.waitForSelector(SELECTOR.notebook, {
+        visible: true,
+      });
+      break;
     default:
       throw Error(
         `report source can only be one of [Dashboard, Visualization]`
       );
   }
-  
   // wait for dynamic page content to render
   await waitForDynamicContent(page);
 
@@ -175,7 +179,6 @@ export const createVisualReport = async (
     screenshot.toString('base64')
   );
   await page.setContent(templateHtml);
-
   // create pdf or png accordingly
   if (reportFormat === FORMAT.pdf) {
     const scrollHeight = await page.evaluate(
@@ -200,7 +203,6 @@ export const createVisualReport = async (
   const timeCreated = curTime.valueOf();
   const fileName = `${getFileName(reportName, curTime)}.${reportFormat}`;
   await browser.close();
-
   return { timeCreated, dataUrl: buffer.toString('base64'), fileName };
 };
 

--- a/kibana-reports/server/utils/validationHelper.ts
+++ b/kibana-reports/server/utils/validationHelper.ts
@@ -41,7 +41,7 @@ export const isValidRelativeUrl = (relativeUrl: string) => {
 export const regexDuration = /^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
 export const regexEmailAddress = /\S+@\S+\.\S+/;
 export const regexReportName = /^[\w\-\s\(\)\[\]\,\_\-+]+$/;
-export const regexRelativeUrl = /^\/(_plugin\/kibana\/app|app)\/(dashboards|visualize|discover)(\?security_tenant=.+|)#\/(view|edit)\/[^\/]+$/;
+export const regexRelativeUrl = /^\/(_plugin\/kibana\/app|app)\/(dashboards|visualize|discover|opendistro-notebooks-kibana)(\?security_tenant=.+|)#\/(view\/|edit\/)?[^\/]+$/;
 
 export const validateReport = async (
   client: ILegacyScopedClusterClient,
@@ -109,16 +109,30 @@ const validateSavedObject = async (
         return 'search';
       case REPORT_TYPE.visualization:
         return 'visualization';
+      case REPORT_TYPE.notebook:
+        return 'notebook';
     }
   };
 
-  const savedObjectId = `${getType(source)}:${getId(url)}`;
-  const params: RequestParams.Exists = {
-    index: '.kibana',
-    id: savedObjectId,
-  };
+  let exist = false;
+  let savedObjectId = '';
+  if (getType(source) === 'notebook') {
+    const notebookId = getId(url);
+    const params: RequestParams.Exists = {
+      index: '.opendistro-notebooks',
+      id: notebookId
+    }
+    exist = await client.callAsCurrentUser('exists', params);
+  }
+  else {
+    savedObjectId = `${getType(source)}:${getId(url)}`;
+    const params: RequestParams.Exists = {
+      index: '.kibana',
+      id: savedObjectId,
+    };
 
-  const exist = await client.callAsCurrentUser('exists', params);
+    exist = await client.callAsCurrentUser('exists', params);    
+  }
   if (!exist) {
     throw Error(`saved object with id ${savedObjectId} does not exist`);
   }

--- a/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportDefinition.kt
+++ b/reports-scheduler/src/main/kotlin/com/amazon/opendistroforelasticsearch/reportsscheduler/model/ReportDefinition.kt
@@ -84,7 +84,7 @@ internal data class ReportDefinition(
     val delivery: Delivery?
 ) : ToXContentObject {
 
-    internal enum class SourceType { Dashboard, Visualization, SavedSearch }
+    internal enum class SourceType { Dashboard, Visualization, SavedSearch, Notebook }
     internal enum class TriggerType { Download, OnDemand, CronSchedule, IntervalSchedule }
     internal enum class DeliveryFormat { LinkOnly, Attachment, Embedded }
     internal enum class FileFormat { Pdf, Png, Csv }


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Adds Kibana notebooks as a report source option in the Reporting plugin page. Visual reports can now be created for a Notebook just like a dashboard or visualization. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.