### PR TITLE
Use `commonlyUsedRanges` from Kibana Settings instead of a constant value

### DIFF
--- a/kibana-reports/public/application.tsx
+++ b/kibana-reports/public/application.tsx
@@ -20,14 +20,13 @@ import { AppPluginStartDependencies } from './types';
 import { OpendistroKibanaReportsApp } from './components/app';
 
 export const renderApp = (
-  { notifications, http, chrome, uiSettings }: CoreStart,
+  { http, chrome, uiSettings }: CoreStart,
   {  }: AppPluginStartDependencies,
   { appBasePath, element }: AppMountParameters
 ) => {
   ReactDOM.render(
     <OpendistroKibanaReportsApp
       basename={appBasePath}
-      notifications={notifications}
       http={http}
       uiSettings={uiSettings}
       chrome={chrome}

--- a/kibana-reports/public/application.tsx
+++ b/kibana-reports/public/application.tsx
@@ -20,8 +20,8 @@ import { AppPluginStartDependencies } from './types';
 import { OpendistroKibanaReportsApp } from './components/app';
 
 export const renderApp = (
-  { notifications, http, chrome }: CoreStart,
-  { navigation }: AppPluginStartDependencies,
+  { notifications, http, chrome, uiSettings }: CoreStart,
+  {  }: AppPluginStartDependencies,
   { appBasePath, element }: AppMountParameters
 ) => {
   ReactDOM.render(
@@ -29,7 +29,7 @@ export const renderApp = (
       basename={appBasePath}
       notifications={notifications}
       http={http}
-      navigation={navigation}
+      uiSettings={uiSettings}
       chrome={chrome}
     />,
     element

--- a/kibana-reports/public/components/app.tsx
+++ b/kibana-reports/public/components/app.tsx
@@ -47,7 +47,6 @@ export interface CoreInterface {
 
 interface OpendistroKibanaReportsAppDeps {
   basename: string;
-  notifications: CoreStart['notifications'];
   http: CoreStart['http'];
   // navigation: NavigationPublicPluginStart;
   chrome: CoreStart['chrome'];

--- a/kibana-reports/public/components/app.tsx
+++ b/kibana-reports/public/components/app.tsx
@@ -31,7 +31,7 @@ import {
   ChromeBreadcrumb,
   IUiSettingsClient,
 } from '../../../../src/core/public';
-import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
+// import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
 
 import { CreateReport } from './report_definitions/create/create_report_definition';
 import { Main } from './main/main';
@@ -49,8 +49,9 @@ interface OpendistroKibanaReportsAppDeps {
   basename: string;
   notifications: CoreStart['notifications'];
   http: CoreStart['http'];
-  navigation: NavigationPublicPluginStart;
+  // navigation: NavigationPublicPluginStart;
   chrome: CoreStart['chrome'];
+  uiSettings: IUiSettingsClient;
 }
 
 const styles: CSS.Properties = {
@@ -61,10 +62,9 @@ const styles: CSS.Properties = {
 
 export const OpendistroKibanaReportsApp = ({
   basename,
-  notifications,
   http,
-  navigation,
   chrome,
+  uiSettings
 }: OpendistroKibanaReportsAppDeps) => {
   // Render the application DOM.
   return (
@@ -117,6 +117,7 @@ export const OpendistroKibanaReportsApp = ({
                       <EditReportDefinition
                         title="Edit Report Definition"
                         httpClient={http}
+                        uiSettings={uiSettings}
                         {...props}
                         setBreadcrumbs={chrome.setBreadcrumbs}
                       />

--- a/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/create/create_report_definition.tsx
@@ -122,6 +122,7 @@ export function CreateReport(props) {
   const [toasts, setToasts] = useState([]);
   const [comingFromError, setComingFromError] = useState(false);
   const [preErrorData, setPreErrorData] = useState({});
+  const { uiSettings } = props;
 
   const [
     showSettingsReportNameError,
@@ -311,6 +312,7 @@ export function CreateReport(props) {
         <EuiSpacer />
         <ReportSettings
           edit={false}
+          uiSettings={uiSettings}
           reportDefinitionRequest={createReportDefinitionRequest}
           httpClientProps={props['httpClient']}
           timeRange={timeRange}

--- a/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
+++ b/kibana-reports/public/components/report_definitions/edit/edit_report_definition.tsx
@@ -40,6 +40,7 @@ export function EditReportDefinition(props) {
   const [toasts, setToasts] = useState([]);
   const [comingFromError, setComingFromError] = useState(false);
   const [preErrorData, setPreErrorData] = useState({});
+  const { uiSettings } = props;
 
   const [
     showSettingsReportNameError,
@@ -63,7 +64,7 @@ export function EditReportDefinition(props) {
   ] = useState(false);
   const [showCronError, setShowCronError] = useState(false);
   const [
-    showEmailRecipientsError, 
+    showEmailRecipientsError,
     setShowEmailRecipientsError
   ] = useState(false);
   const [
@@ -298,6 +299,7 @@ export function EditReportDefinition(props) {
         <EuiSpacer />
         <ReportSettings
           edit={true}
+          uiSettings={uiSettings}
           editDefinitionId={reportDefinitionId}
           reportDefinitionRequest={editReportDefinitionRequest}
           httpClientProps={props['httpClient']}

--- a/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings.test.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/__tests__/report_settings.test.tsx
@@ -19,6 +19,7 @@ import { ReportSettings } from '../report_settings';
 import 'babel-polyfill';
 import 'regenerator-runtime';
 import httpClientMock from '../../../../../test/httpMockClient';
+import uiSettingsMock from '../../../../../test/uiSettingsMock';
 import { configure, mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { act } from 'react-dom/test-utils';
@@ -103,6 +104,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -147,6 +149,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -192,6 +195,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -240,6 +244,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -288,6 +293,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -336,6 +342,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={true}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -347,7 +354,7 @@ describe('<ReportSettings /> panel', () => {
     expect(container.firstChild).toMatchSnapshot();
     await act(() => promise);
   });
-  
+
 
   test('dashboard create from in-context', async () => {
     window = Object.create(window);
@@ -392,6 +399,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -450,6 +458,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -510,6 +519,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -558,6 +568,7 @@ describe('<ReportSettings /> panel', () => {
     const component = shallow(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -606,6 +617,7 @@ describe('<ReportSettings /> panel', () => {
     const component = mount(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -624,7 +636,7 @@ describe('<ReportSettings /> panel', () => {
 
     act(() => {
       comboBox.props().onChange([{ value: 'test', label: 'test' }]);
-    }); 
+    });
     component.update();
 
     await act(() => promise);
@@ -663,6 +675,7 @@ describe('<ReportSettings /> panel', () => {
     const component = mount(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -692,6 +705,7 @@ describe('<ReportSettings /> panel', () => {
     const { container } = render(
       <ReportSettings
         edit={false}
+        uiSettings={uiSettingsMock}
         reportDefinitionRequest={emptyRequest}
         httpClientProps={httpClientMock}
         timeRange={timeRange}
@@ -701,6 +715,47 @@ describe('<ReportSettings /> panel', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+    await act(() => promise);
+  });
+
+  test('load commonlyUsedRanges from uiSettings service', async () => {
+    const promise = Promise.resolve();
+    uiSettingsMock.get = jest.fn((key) => [
+      {
+        from: 'now/d',
+        to: 'now/d',
+        display: 'Foo'
+      }
+    ]);
+
+    const component = mount(
+      <ReportSettings
+        edit={false}
+        uiSettings={uiSettingsMock}
+        reportDefinitionRequest={emptyRequest}
+        httpClientProps={httpClientMock}
+        timeRange={timeRange}
+        showSettingsReportNameError={true}
+        showTimeRangeError={true}
+      />
+    );
+    await act(() => promise);
+
+    const superDatePicker =  component.find('EuiSuperDatePicker').at(0);
+
+    expect(superDatePicker.prop('commonlyUsedRanges')).toEqual(
+      [
+        {
+          start: 'now/d',
+          end: 'now/d',
+          label: 'Foo'
+        }
+      ]
+    );
+
+    expect(uiSettingsMock.get.mock.calls.length).toBeGreaterThan(0);
+    expect(uiSettingsMock.get.mock.calls[0][0]).toBe('timepicker:quickRanges');
+
     await act(() => promise);
   });
 });

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings.tsx
@@ -70,6 +70,7 @@ type ReportSettingProps = {
   showSettingsReportSourceError: boolean;
   settingsReportSourceErrorMessage: string;
   showTimeRangeError: boolean;
+  uiSettings: any;
 };
 
 export function ReportSettings(props: ReportSettingProps) {
@@ -84,6 +85,7 @@ export function ReportSettings(props: ReportSettingProps) {
     showSettingsReportSourceError,
     settingsReportSourceErrorMessage,
     showTimeRangeError,
+    uiSettings,
   } = props;
 
   const [reportName, setReportName] = useState('');
@@ -727,6 +729,7 @@ export function ReportSettings(props: ReportSettingProps) {
         {displaySavedSearchSelect}
         <TimeRangeSelect
           timeRange={timeRange}
+          uiSettings={uiSettings}
           reportDefinitionRequest={reportDefinitionRequest}
           edit={edit}
           id={editDefinitionId}

--- a/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/report_settings_constants.tsx
@@ -65,26 +65,3 @@ export const REPORT_SOURCE_TYPES = {
   visualization: 'Visualization',
   savedSearch: 'Saved search',
 };
-
-export const commonTimeRanges = [
-  {
-    start: 'now/d',
-    end: 'now',
-    label: 'Today so far'
-  },
-  {
-    start: 'now/w',
-    end: 'now',
-    label: 'Week to date'
-  },
-  {
-    start: 'now/M',
-    end: 'now',
-    label: 'Month to date'
-  },
-  {
-    start: 'now/y',
-    end: 'now',
-    label: 'Year to date'
-  }
-]

--- a/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -22,7 +22,6 @@ import {
   EuiGlobalToastList,
   EuiSuperDatePicker,
 } from '@elastic/eui';
-import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 
 export function TimeRangeSelect(props) {
   const {
@@ -194,7 +193,7 @@ export function TimeRangeSelect(props) {
   };
 
   const commonlyUsedRanges = uiSettings!
-    .get(UI_SETTINGS.TIMEPICKER_QUICK_RANGES)
+    .get('timepicker:quickRanges')
     .map(({ from, to, display }: { from: string; to: string; display: string }) => {
       return {
         start: from,

--- a/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
+++ b/kibana-reports/public/components/report_definitions/report_settings/time_range.tsx
@@ -22,7 +22,7 @@ import {
   EuiGlobalToastList,
   EuiSuperDatePicker,
 } from '@elastic/eui';
-import { commonTimeRanges } from './report_settings_constants';
+import { UI_SETTINGS } from '../../../../../../src/plugins/data/common';
 
 export function TimeRangeSelect(props) {
   const {
@@ -32,6 +32,7 @@ export function TimeRangeSelect(props) {
     id,
     httpClientProps,
     showTimeRangeError,
+    uiSettings
   } = props;
 
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState([]);
@@ -192,6 +193,15 @@ export function TimeRangeSelect(props) {
     setIsLoading(false);
   };
 
+  const commonlyUsedRanges = uiSettings!
+    .get(UI_SETTINGS.TIMEPICKER_QUICK_RANGES)
+    .map(({ from, to, display }: { from: string; to: string; display: string }) => {
+      return {
+        start: from,
+        end: to,
+        label: display,
+      };
+    });
 
   return (
     <div>
@@ -209,7 +219,7 @@ export function TimeRangeSelect(props) {
             end={end}
             onTimeChange={onTimeChange}
             showUpdateButton={false}
-            commonlyUsedRanges={commonTimeRanges}
+            commonlyUsedRanges={commonlyUsedRanges}
           />
         </EuiFormRow>
       </div>

--- a/kibana-reports/public/plugin.ts
+++ b/kibana-reports/public/plugin.ts
@@ -30,8 +30,10 @@ import { PLUGIN_NAME } from '../common';
 export class OpendistroKibanaReportsPlugin
   implements
     Plugin<
+      OpendistroKibanaReportsPluginStart,
       OpendistroKibanaReportsPluginSetup,
-      OpendistroKibanaReportsPluginStart
+      AppPluginStartDependencies,
+      any
     > {
   public setup(core: CoreSetup): OpendistroKibanaReportsPluginSetup {
     // Register an application into the side navigation menu

--- a/kibana-reports/public/types.ts
+++ b/kibana-reports/public/types.ts
@@ -13,13 +13,16 @@
  * permissions and limitations under the License.
  */
 
-import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+// import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import { DataPublicPluginStart } from '../../../src/plugins/data/public';
 
-export interface OpendistroKibanaReportsPluginSetup {}
+export interface OpendistroKibanaReportsPluginSetup {
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface OpendistroKibanaReportsPluginStart {}
 
 export interface AppPluginStartDependencies {
-  navigation: NavigationPublicPluginStart;
+  // navigation: NavigationPublicPluginStart;
+  data: DataPublicPluginStart;
 }

--- a/kibana-reports/test/uiSettingsMock.js
+++ b/kibana-reports/test/uiSettingsMock.js
@@ -1,0 +1,20 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+const uiSettingsMock = jest.fn();
+
+uiSettingsMock.get = jest.fn((key) => ([]));
+
+export default uiSettingsMock;


### PR DESCRIPTION
*Issue #, if available:* #351

*Description of changes:*

* Add the `uiSettings` service from `Data` plugin as dependency
* Removes unused dependencies (notifications and navigation)
* Change `time_range` component to use `commonlyUsedRanges` from `uiSettings` (following default behavior for `EuiSuperDatePicker` across entire kibana), allowing user to override defaults 
* Removed the constant that was used for `commonlyUsedRanges`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.