### PR TITLE
Improve sanity tests

### DIFF
--- a/kibana-reports/server/routes/utils/dataReportHelpers.ts
+++ b/kibana-reports/server/routes/utils/dataReportHelpers.ts
@@ -223,6 +223,8 @@ function traverse(data, keys, result = {}) {
  */
 function sanitize(doc: any) {
   for (const field in doc) {
+    if (doc[field] == null)
+      continue
     if (
       doc[field].toString().startsWith('+') ||
       doc[field].toString().startsWith('-') ||


### PR DESCRIPTION
Pass processing if doc[field] == null
Based on https://github.com/opendistro-for-elasticsearch/kibana-reports/issues/327#issuecomment-796479152

*Issue #327 :*

*Description of changes:*
Calling doc [field] .toString () for null-values was throwing an error. Added check for null-value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.