### PR TITLE
Remove visualization editor in visualization reports

### DIFF
--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -129,10 +129,10 @@ export const createVisualReport = async (
   });
 
   let buffer: Buffer;
-  // remove top nav bar
+  // remove unwanted elements
   await page.evaluate(
     /* istanbul ignore next */
-    () => {
+    (reportSource, REPORT_TYPE) => {
       // remove buttons
       document
         .querySelectorAll("[class^='euiButton']")
@@ -141,8 +141,17 @@ export const createVisualReport = async (
       document
         .querySelectorAll("[class^='euiHeader']")
         .forEach((e) => e.remove());
+      // remove visualization editor
+      if (reportSource === REPORT_TYPE.visualization) {
+        document
+          .querySelector('[data-test-subj="splitPanelResizer"]')
+          ?.remove();
+        document.querySelector('.visEditor__collapsibleSidebar')?.remove();
+      }
       document.body.style.paddingTop = '0px';
-    }
+    },
+    reportSource,
+    REPORT_TYPE
   );
   // force wait for any resize to load after the above DOM modification
   await page.waitFor(1000);


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

*Issue #, if available:*
- https://github.com/opensearch-project/dashboards-reports/issues/47

*Description of changes:*
- remove the visualization editor when capturing report

![image](https://user-images.githubusercontent.com/28062824/118321738-df644180-b4b2-11eb-9fd4-ef5a967d1cf1.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.