### PR TITLE
[Not ready to merge] forward extra needed headers to headless browser

### DIFF
--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -76,12 +76,16 @@ export const DEFAULT_MAX_SIZE = 10000;
 export const DEFAULT_REPORT_HEADER = '<h1>Open Distro Kibana Reports</h1>';
 
 export const SECURITY_CONSTANTS = {
-  AUTH_COOKIE_NAME: 'security_authentication',
   TENANT_LOCAL_STORAGE_KEY: 'opendistro::security::tenant::show_popup',
-  PROXY_AUTH_USER_HEADER: 'x-proxy-user',
-  PROXY_AUTH_ROLES_HEADER: 'x-proxy-roles',
-  PROXY_AUTH_IP_HEADER: 'x-forwarded-for',
 };
+
+export const EXTRA_HEADERS = [
+  'cookie',
+  'x-amzn-aes-auth-required',
+  'x-forward-proto',
+  'x-proxy-user',
+  'x-proxy-roles',
+];
 
 export const CHROMIUM_PATH = `${__dirname}/../../../.chromium/headless_shell`;
 

--- a/kibana-reports/server/routes/utils/constants.ts
+++ b/kibana-reports/server/routes/utils/constants.ts
@@ -82,7 +82,6 @@ export const SECURITY_CONSTANTS = {
 export const EXTRA_HEADERS = [
   'cookie',
   'x-amzn-aes-auth-required',
-  'x-forward-proto',
   'x-proxy-user',
   'x-proxy-roles',
 ];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Instead of only forwarding the `security_authentication`, this change will forward all cookies to handle different security setup
- rewrite the logic of https://github.com/opendistro-for-elasticsearch/kibana-reports/commit/0160a02e3a5d26b9ff279deb5831ceb71b5f8893 to pick up proxy-auth headers
- add extra required headers to handle different security setting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.