### PR TITLE
add test case to check "doc[field] == null" in csv report generation

### DIFF
--- a/kibana-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/kibana-reports/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -278,6 +278,20 @@ describe('test create saved search report', () => {
   }, 20000);
 });
 
+test('create report for data set contains null field value', async () => {
+  const hits = [
+    hit({ category: 'c1', customer_gender: 'Ma' }),
+    hit({ category: 'c2', customer_gender: 'le' }),
+    hit({ category: 'c3', customer_gender: null }),
+  ];
+  const client = mockEsClient(hits);
+  const { dataUrl } = await createSavedSearchReport(input, client);
+
+  expect(dataUrl).toEqual(
+    'category,customer_gender\n' + 'c1,Ma\n' + 'c2,le\n' + 'c3, '
+  );
+}, 20000);
+
 /**
  * Mock Elasticsearch client and return different mock objects based on endpoint and parameters.
  */


### PR DESCRIPTION
*Issue #, if available:*
#361
*Description of changes:*
Add missing test case for the fix "pass doc[field] == null"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.