### PR TITLE
remove exit full screen button

### DIFF
--- a/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
+++ b/kibana-reports/server/routes/utils/visual_report/visualReportHelper.ts
@@ -123,6 +123,10 @@ export const createVisualReport = async (
       document
         .querySelectorAll("[class^='euiHeader']")
         .forEach((e) => e.remove());
+      // remove exit full screen button
+      document
+        .querySelectorAll("[class^='dshExitFullScreenButton']")
+        .forEach(e => e.remove())
       // remove visualization editor
       if (reportSource === REPORT_TYPE.visualization) {
         document


### PR DESCRIPTION
Hello,

I'm using your plugin to export images from my Kibana dashboard.
I'm trying to get as little clutter on the export as possible.
Using the plugin it is possible to export visualizations in full screen.
In that case however a small button to exit the full screen view is rendered.
This small change removes this button.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.